### PR TITLE
proxies/parser: add rust_parser_proxy_clone() method

### DIFF
--- a/actiondb-parser/src/lib.rs
+++ b/actiondb-parser/src/lib.rs
@@ -12,6 +12,7 @@ use actiondb::matcher::Matcher;
 use syslog_ng_sys::{RustParser,
                     LogMessage};
 
+#[derive(Clone)]
 pub struct ActiondbParser {
     matcher: Option<Matcher>
 }
@@ -66,6 +67,9 @@ impl RustParser for ActiondbParser {
                 debug!("ActiondbParser not supported key: {:?}", key) ;
             }
         };
+    }
 
+    fn boxed_clone(&self) -> Box<RustParser> {
+        Box::new(self.clone())
     }
 }

--- a/dummy-parser/src/lib.rs
+++ b/dummy-parser/src/lib.rs
@@ -7,6 +7,7 @@ extern crate syslog_ng_sys;
 use syslog_ng_sys::{RustParser,
                     LogMessage};
 
+#[derive(Clone)]
 pub struct DummyParser;
 
 impl DummyParser {
@@ -30,6 +31,10 @@ impl RustParser for DummyParser {
 
     fn set_option(&mut self, key: String, value: String) {
         debug!("DummyParser: set_option(key={}, value={})", &key, &value);
+    }
+    
+    fn boxed_clone(&self) -> Box<RustParser> {
+        Box::new(self.clone())
     }
 }
 

--- a/include/rust-parser-proxy.h
+++ b/include/rust-parser-proxy.h
@@ -20,4 +20,7 @@ rust_parser_proxy_init(struct RustParserProxy* s);
 struct RustParserProxy*
 rust_parser_proxy_new(const gchar* parser_name);
 
+struct RustParserProxy*
+rust_parser_proxy_clone(struct RustParserProxy *self);
+
 #endif

--- a/src/proxies/parser.rs
+++ b/src/proxies/parser.rs
@@ -61,6 +61,12 @@ pub extern fn rust_parser_proxy_new(parser_name: *const c_char) -> Box<RustParse
     }
 }
 
+#[no_mangle]
+pub extern fn rust_parser_proxy_clone(slf: &RustParserProxy) -> Box<RustParserProxy> {
+    let cloned = (*slf).clone();
+    Box::new(cloned)
+}
+
 fn create_parser_impl(name: &str) -> Option<Box<RustParserProxy>> {
     let parser: Option<Box<RustParser>> = match name {
         "dummy" => {

--- a/syslog-ng-sys/src/parser.rs
+++ b/syslog-ng-sys/src/parser.rs
@@ -11,8 +11,18 @@ impl RustParserProxy {
     }
 }
 
+impl Clone for RustParserProxy {
+    fn clone(&self) -> RustParserProxy {
+        trace!("Cloning RustParserProxy");
+        RustParserProxy{
+            parser: self.parser.boxed_clone()
+        }
+    }
+}
+
 pub trait RustParser {
     fn init(&mut self) -> bool { true }
     fn set_option(&mut self, _: String, _: String) {}
     fn process(&self, msg: &mut LogMessage, input: &str) -> bool;
+    fn boxed_clone(&self) -> Box<RustParser>;
 }


### PR DESCRIPTION
It can be used to clone a complete RustParserProxy struct. It's needed
by LogPipe's clone() method.

Fixes #7 

Signed-off-by: Tibor Benke <ihrwein@gmail.com>