### PR TITLE
Incorporate syslog-ng-rs repository

### DIFF
--- a/actiondb-parser/Cargo.toml
+++ b/actiondb-parser/Cargo.toml
@@ -20,7 +20,7 @@ crate_type = ["rlib", "dylib"]
 [dependencies]
 log = "0.3"
 actiondb = "0.7.0"
-syslog-ng-common = "0.8.0"
+syslog-ng-common = { path = "../syslog-ng-rs/syslog-ng-common" }
 clap = "2.3"
 
 [build-dependencies]

--- a/correlation-parser/Cargo.toml
+++ b/correlation-parser/Cargo.toml
@@ -10,7 +10,7 @@ crate_type = ["dylib", "rlib"]
 [dependencies]
 log = "0.3"
 env_logger = "0.3"
-syslog-ng-common = "0.8.0"
+syslog-ng-common = { path = "../syslog-ng-rs/syslog-ng-common" }
 
 [dependencies.correlation]
 path = "correlation"

--- a/python-parser/Cargo.toml
+++ b/python-parser/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 crate-type = ["rlib", "dylib"]
 
 [dependencies]
-syslog-ng-common = "0.8"
+syslog-ng-common = { path = "../syslog-ng-rs/syslog-ng-common" }
 cpython = { git = "https://github.com/ihrwein/rust-cpython.git" }
 log = "0.3"
 env_logger = "0.3"

--- a/regex-parser/Cargo.toml
+++ b/regex-parser/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 crate-type = ["rlib", "dylib"]
 
 [dependencies]
-syslog-ng-common = "0.8"
+syslog-ng-common = { path = "../syslog-ng-rs/syslog-ng-common" }
 regex = "0.1"
 log = "0.3"
 

--- a/syslog-ng-rs/.gitignore
+++ b/syslog-ng-rs/.gitignore
@@ -1,0 +1,4 @@
+*/target
+*/Cargo.lock
+*/tags
+tags

--- a/syslog-ng-rs/LICENSE-APACHE
+++ b/syslog-ng-rs/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/syslog-ng-rs/LICENSE-MIT
+++ b/syslog-ng-rs/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/syslog-ng-rs/README.md
+++ b/syslog-ng-rs/README.md
@@ -1,0 +1,23 @@
+# syslog-ng-rs
+
+High and low level bindings for developing modules for syslog-ng.
+
+## Directories
+
+* syslog-ng-sys: low level bindings
+* syslog-ng-common: high level bindings
+* syslog-ng-build: crate to simplify build scripts
+
+## License
+
+Licensed under either of
+ * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any
+additional terms or conditions.
+

--- a/syslog-ng-rs/syslog-ng-build/Cargo.toml
+++ b/syslog-ng-rs/syslog-ng-build/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "syslog-ng-build"
+version = "0.2.0"
+authors = ["Tibor Benke <ihrwein@gmail.com>"]
+homepage = "https://github.com/ihrwein/syslog-ng-rs"
+repository = "https://github.com/ihrwein/syslog-ng-rs"
+keywords = ["syslog-ng"]
+description = "Build script helpers"
+license = "MIT/Apache-2.0"
+
+[dependencies]
+gcc = "0.3"
+pkg-config = "0.3"

--- a/syslog-ng-rs/syslog-ng-build/src/lib.rs
+++ b/syslog-ng-rs/syslog-ng-build/src/lib.rs
@@ -1,0 +1,142 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+extern crate pkg_config;
+extern crate gcc;
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+const RUST_DEPS_A_NAME: &'static str = "syslog-ng-native-connector";
+
+fn create_plugins(parser_name: Option<&str>) -> String {
+    let head = r#"
+static Plugin native_plugins[] =
+{
+    "#;
+    let tail = r#"
+};
+    "#;
+    let middle = match parser_name {
+        Some(name) => {
+            format!(r#"
+  {{
+    .type = LL_CONTEXT_PARSER,
+    .name = "{name}",
+    .parser = &native_parser,
+ }},
+            "#,
+                    name = name)
+        }
+        None => format!(""),
+    };
+
+    format!("{}{}{}", head, middle, tail)
+}
+
+fn create_module_init(canonical_name: &str) -> String {
+    let name = canonical_name.replace("-", "_");
+    format!(r#"
+gboolean
+{name}_module_init(GlobalConfig *cfg, CfgArgs *args)
+{{
+  plugin_register(cfg, native_plugins, G_N_ELEMENTS(native_plugins));
+  return TRUE;
+}}
+    "#,
+            name = name)
+}
+
+fn create_module_info(canonical_name: &str, description: &str) -> String {
+    format!(r#"
+const ModuleInfo module_info =
+{{
+  .canonical_name = "{name}",
+  .version = SYSLOG_NG_VERSION,
+  .description = "{description}",
+  .core_revision = VERSION_CURRENT_VER_ONLY,
+  .plugins = native_plugins,
+  .plugins_len = G_N_ELEMENTS(native_plugins),
+}};
+    "#,
+            name = canonical_name,
+            description = description)
+}
+
+fn get_out_dir_file_path(filename: &str) -> PathBuf {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    Path::new(&out_dir).join(filename)
+}
+
+pub fn create_module_content(canonical_name: &str,
+                             description: &str,
+                             parser_name: Option<&str>)
+                             -> String {
+    let header = r#"
+#include "cfg-parser.h"
+#include "plugin.h"
+#include "plugin-types.h"
+
+CfgParser native_parser;
+    "#;
+
+    format!("{header}{plugins}{module_init}{module_info}",
+            header = header,
+            plugins = create_plugins(parser_name),
+            module_init = create_module_init(canonical_name),
+            module_info = create_module_info(canonical_name, description))
+}
+
+fn link_against_rust_deps() {
+    match pkg_config::Config::new().statik(true).find(RUST_DEPS_A_NAME) {
+        Ok(_) => {}
+        Err(err) => {
+            println!("{}", err);
+        }
+    }
+}
+
+fn compile_and_link_module<P: AsRef<Path>>(dest_path: P) {
+    let mut compiler = gcc::Config::new();
+    match pkg_config::find_library("syslog-ng") {
+        Ok(lib) => {
+            for i in lib.include_paths {
+                compiler.include(i);
+            }
+
+            compiler.flag("-c")
+                    .file(dest_path)
+                    .compile("librust-module.a");
+        }
+        Err(err) => {
+            println!("{}", err);
+        }
+    }
+}
+
+fn write_module_content_to_file<P: AsRef<Path>>(content: &str, path: P) {
+    let mut module_file = File::create(&path).unwrap();
+    module_file.write((&content).as_bytes())
+               .ok()
+               .expect("Failed to write module info during build");
+}
+
+fn link_against_module(content: &str) {
+    let module_file_name = "module.c";
+    let dest_path = get_out_dir_file_path(module_file_name);
+    write_module_content_to_file(&content, &dest_path);
+    compile_and_link_module(&dest_path);
+}
+
+pub fn create_module(canonical_name: &str, description: &str, parser_name: Option<&str>) {
+    link_against_rust_deps();
+    let module_content = create_module_content(canonical_name, description, parser_name);
+    link_against_module(&module_content);
+}

--- a/syslog-ng-rs/syslog-ng-common/Cargo.toml
+++ b/syslog-ng-rs/syslog-ng-common/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "syslog-ng-common"
+version = "0.8.0"
+authors = ["Tibor Benke <ihrwein@gmail.com>"]
+homepage = "https://github.com/ihrwein/syslog-ng-rs"
+repository = "https://github.com/ihrwein/syslog-ng-rs"
+keywords = ["syslog-ng"]
+description = "High level bindings for syslog-ng"
+license = "MIT/Apache-2.0"
+
+[dependencies]
+log = "0.3"
+syslog-ng-sys = "0.3"
+glib = "0.0.8"
+glib-sys = "0.3.0"
+
+[[test]]
+name = "template_functions"
+harness = false

--- a/syslog-ng-rs/syslog-ng-common/src/cfg.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/cfg.rs
@@ -1,0 +1,135 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use syslog_ng_sys::cfg;
+use std::ffi::CStr;
+
+enum InternalState {
+    Owned(*mut cfg::GlobalConfig),
+    Borrowed(*mut cfg::GlobalConfig),
+}
+
+pub struct GlobalConfig(InternalState);
+
+impl GlobalConfig {
+    pub fn new(version: i32) -> GlobalConfig {
+        let cfg = unsafe { cfg::cfg_new(version) };
+        GlobalConfig(InternalState::Owned(cfg))
+    }
+
+    pub fn borrow(cfg: *mut cfg::GlobalConfig) -> GlobalConfig {
+        GlobalConfig(InternalState::Borrowed(cfg))
+    }
+
+    pub fn get_user_version(&self) -> (u8, u8) {
+        let ptr = self.raw_ptr();
+        let mut version = unsafe { cfg::cfg_get_user_version(ptr) };
+
+        if version < 0 {
+            error!("User config version must be greater than 0, using 0 as version");
+            version = 0;
+        }
+
+        convert_version(version as u16)
+    }
+
+    pub fn get_parsed_version(&self) -> (u8, u8) {
+        let ptr = self.raw_ptr();
+        let mut version = unsafe { cfg::cfg_get_parsed_version(ptr) };
+
+        if version < 0 {
+            error!("Parsed config version must be greater than 0, using 0 as version");
+            version = 0;
+        }
+
+        convert_version(version as u16)
+    }
+
+    pub fn get_filename(&self) -> &CStr {
+        let ptr = self.raw_ptr();
+        unsafe { CStr::from_ptr(cfg::cfg_get_filename(ptr)) }
+    }
+
+    pub fn raw_ptr(&self) -> *mut cfg::GlobalConfig {
+        match self.0 {
+            InternalState::Owned(ptr) => ptr,
+            InternalState::Borrowed(ptr) => ptr,
+        }
+    }
+}
+
+impl Drop for GlobalConfig {
+    fn drop(&mut self) {
+        if let InternalState::Owned(ptr) = self.0 {
+            unsafe { cfg::cfg_free(ptr) };
+        }
+    }
+}
+
+fn hex_to_dec(hex: u8) -> u8 {
+    let mut dec = 0;
+    let mut shifted_hex = hex;
+
+    for i in 0..2 {
+        dec += (shifted_hex % 16) * 10u8.pow(i);
+        shifted_hex >>= 4;
+    }
+
+    dec
+}
+
+fn convert_version(version: u16) -> (u8, u8) {
+    let minor = hex_to_dec(version as u8);
+    let major = hex_to_dec((version >> 8) as u8);
+    (major, minor)
+}
+
+#[test]
+fn one_digit_hex_number_when_converted_to_decimal_works() {
+    let dec = hex_to_dec(0x3);
+    assert_eq!(dec, 3);
+}
+
+#[test]
+fn more_digits_hex_number_when_converted_to_decimal_works() {
+    let dec = hex_to_dec(0x22);
+    assert_eq!(dec, 22);
+}
+
+#[test]
+fn hex_version_when_converted_to_minor_version_works() {
+    let version = 0x0316;
+
+    let (_, minor) = convert_version(version);
+    assert_eq!(minor, 16);
+}
+
+#[test]
+fn hex_version_when_converted_to_major_version_works() {
+    let version = 0x0316;
+
+    let (major, _) = convert_version(version);
+    assert_eq!(major, 3);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use SYSLOG_NG_INITIALIZED;
+    use syslog_ng_global_init;
+
+    #[test]
+    fn test_borrowed_configuration_is_not_freed_on_destruction() {
+        SYSLOG_NG_INITIALIZED.call_once(|| {
+            unsafe { syslog_ng_global_init(); }
+        });
+        let owned = GlobalConfig::new(0x0308);
+        let _ = GlobalConfig::borrow(owned.raw_ptr());
+    }
+}

--- a/syslog-ng-rs/syslog-ng-common/src/formatter.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/formatter.rs
@@ -1,0 +1,46 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use std::fmt::Write;
+
+#[derive(Clone)]
+pub struct MessageFormatter {
+    buffer: String,
+    prefix: Option<String>,
+}
+
+impl MessageFormatter {
+    pub fn new() -> MessageFormatter {
+        MessageFormatter {
+            buffer: String::new(),
+            prefix: None,
+        }
+    }
+
+    pub fn set_prefix(&mut self, prefix: String) {
+        self.prefix = Some(prefix)
+    }
+
+    pub fn format<'a, 'b, 'c>(&'a mut self, key: &'b str, value: &'c str) -> (&'a str, &'c str) {
+        self.buffer.clear();
+        self.apply_prefix(key);
+        (&self.buffer, value)
+    }
+
+    fn apply_prefix(&mut self, key: &str) {
+        match self.prefix.as_ref() {
+            Some(prefix) => {
+                let _ = self.buffer.write_str(prefix);
+                let _ = self.buffer.write_str(key);
+            }
+            None => {
+                let _ = self.buffer.write_str(key);
+            }
+        };
+    }
+}

--- a/syslog-ng-rs/syslog-ng-common/src/lib.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/lib.rs
@@ -1,0 +1,54 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+#[macro_use]
+extern crate log;
+
+#[macro_use]
+extern crate syslog_ng_sys;
+extern crate glib;
+extern crate glib_sys;
+
+use std::sync::{Once, ONCE_INIT};
+
+#[macro_use]
+mod proxies;
+mod logger;
+mod messages;
+mod formatter;
+mod logmsg;
+mod cfg;
+pub mod sys;
+mod logparser;
+mod logpipe;
+pub mod mock;
+pub mod logtemplate;
+mod plugin;
+
+pub use syslog_ng_sys::{c_int, c_char, ssize_t};
+pub use logparser::LogParser;
+pub use logmsg::LogMessage;
+pub use formatter::MessageFormatter;
+pub use logger::init_logger;
+pub use cfg::GlobalConfig;
+pub use proxies::parser::{OptionError, Parser, ParserBuilder, ParserProxy};
+pub use logpipe::{LogPipe, Pipe};
+pub use logtemplate::{LogTemplate, LogTemplateOptions, LogTimeZone};
+pub use plugin::Plugin;
+
+#[allow(dead_code)]
+pub static SYSLOG_NG_INITIALIZED: Once = ONCE_INIT;
+
+pub unsafe fn syslog_ng_global_init() {
+    use syslog_ng_sys::resolved_configurable_paths as c_paths;
+
+    c_paths::resolved_configurable_paths_init(&mut c_paths::resolvedConfigurablePaths);
+    sys::logmsg::log_msg_registry_init();
+    sys::logmsg::log_tags_global_init();
+    sys::logtemplate::log_template_global_init();
+}

--- a/syslog-ng-rs/syslog-ng-common/src/logger.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/logger.rs
@@ -1,0 +1,42 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use log::{LogRecord, LogMetadata, Log, LogLevelFilter};
+use messages::{InternalMessageSender, Msg};
+
+use log;
+
+pub fn init_logger() {
+    let _ = log::set_logger(|max_log_level| {
+        max_log_level.set(InternalLogger::level());
+        Box::new(InternalLogger)
+    });
+}
+
+
+pub struct InternalLogger;
+
+impl InternalLogger {
+    pub fn level() -> LogLevelFilter {
+        InternalMessageSender::level()
+    }
+}
+
+impl Log for InternalLogger {
+    fn enabled(&self, metadata: &LogMetadata) -> bool {
+        metadata.level() <= InternalMessageSender::level()
+    }
+
+    fn log(&self, record: &LogRecord) {
+        if self.enabled(record.metadata()) {
+            let message = format!("{}", record.args());
+            let level = Msg::from(record.level());
+            InternalMessageSender::create_and_send(level, message);
+        }
+    }
+}

--- a/syslog-ng-rs/syslog-ng-common/src/logmsg/mod.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/logmsg/mod.rs
@@ -1,0 +1,159 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use syslog_ng_sys::{LogTagId, logmsg};
+use syslog_ng_sys::types::*;
+
+use std::collections::BTreeMap;
+use std::mem;
+use std::slice::from_raw_parts;
+use std::ffi::{CStr, CString};
+
+#[cfg(test)]
+mod test;
+
+pub struct NVHandle(logmsg::NVHandle);
+pub struct LogMessage(pub *mut logmsg::LogMessage);
+
+impl Drop for LogMessage {
+    fn drop(&mut self) {
+        unsafe { logmsg::log_msg_unref(self.0) }
+    }
+}
+
+unsafe impl Send for LogMessage {}
+
+impl Clone for LogMessage {
+    fn clone(&self) -> LogMessage {
+        LogMessage::wrap_raw(self.0)
+    }
+}
+
+impl LogMessage {
+    pub fn new() -> LogMessage {
+        unsafe {
+            let msg = logmsg::log_msg_new_empty();
+            assert!(msg != ::std::ptr::null_mut());
+            LogMessage(msg)
+        }
+    }
+
+    pub fn wrap_raw(raw: *mut ::sys::LogMessage) -> LogMessage {
+        let referenced = unsafe {logmsg::log_msg_ref(raw)};
+        LogMessage(referenced)
+    }
+
+    pub fn into_raw(self) -> *mut ::sys::LogMessage {
+        // self will be destroyed by the end of this functions so we need to
+        // increment the refcount
+        unsafe {logmsg::log_msg_ref(self.0)}
+    }
+
+    pub fn get_value_handle(value_name: &str) -> NVHandle {
+        unsafe {
+            let name = CString::new(value_name).unwrap();
+            NVHandle(logmsg::log_msg_get_value_handle(name.as_ptr()))
+        }
+    }
+
+    pub fn get<K: Into<NVHandle>>(&self, key: K) -> Option<&[u8]> {
+        let handle = key.into();
+        let mut size: ssize_t = 0;
+        let value = unsafe { logmsg::__log_msg_get_value(self.0, handle.0, &mut size) };
+        if size > 0 {
+            let value = unsafe { from_raw_parts(value as *const u8, size as usize) };
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    pub fn insert<K: Into<NVHandle>>(&mut self, key: K, value: &[u8]) {
+        let handle = key.into();
+        unsafe {
+            logmsg::log_msg_set_value(self.0, handle.0, value.as_ptr() as *const i8, value.len() as isize);
+        }
+    }
+
+    pub fn set_tag(&mut self, tag: &[u8]) {
+        let c_tag = CString::new(tag).unwrap();
+        unsafe {
+            logmsg::log_msg_set_tag_by_name(self.0, c_tag.as_ptr());
+        }
+    }
+
+    pub fn values(&self) -> BTreeMap<Vec<u8>, Vec<u8>> {
+        let mut values = BTreeMap::new();
+        unsafe {
+            let user_data = mem::transmute::<&mut BTreeMap<Vec<u8>, Vec<u8>>,
+                                             *mut c_void>(&mut values);
+            logmsg::log_msg_values_foreach(self.0, insert_kvpair_to_map, user_data);
+        }
+        values
+    }
+
+    pub fn tags(&self) -> Vec<Vec<u8>> {
+        let mut tags = Vec::new();
+        unsafe {
+            let user_data = mem::transmute::<&mut Vec<Vec<u8>>, *mut c_void>(&mut tags);
+            logmsg::log_msg_tags_foreach(self.0, insert_tag_to_vec, user_data);
+        }
+        tags
+    }
+}
+
+extern "C" fn insert_tag_to_vec(_: *const logmsg::LogMessage,
+                                _: LogTagId,
+                                name: *const c_char,
+                                user_data: *mut c_void)
+                                -> bool {
+    unsafe {
+        let bytes = CStr::from_ptr(name).to_bytes().to_vec();
+        let mut vec: &mut Vec<Vec<u8>> = mem::transmute(user_data);
+        vec.push(bytes);
+    }
+    false
+}
+
+extern "C" fn insert_kvpair_to_map(_: logmsg::NVHandle,
+                                   name: *const c_char,
+                                   value: *const c_char,
+                                   value_len: ssize_t,
+                                   user_data: *mut c_void)
+                                   -> bool {
+    unsafe {
+        let name = CStr::from_ptr(name).to_bytes().to_vec();
+        let value = from_raw_parts(value as *const u8, value_len as usize).to_vec();
+        let mut map: &mut BTreeMap<Vec<u8>, Vec<u8>> = mem::transmute(user_data);
+        map.insert(name, value);
+    }
+    false
+}
+
+impl<'a> Into<NVHandle> for &'a str {
+    fn into(self) -> NVHandle {
+        let name = CString::new(self).unwrap();
+        let handle = unsafe { logmsg::log_msg_get_value_handle(name.as_ptr()) };
+        NVHandle(handle)
+    }
+}
+
+impl<'a> Into<NVHandle> for &'a [u8] {
+    fn into(self) -> NVHandle {
+        let mut name = Vec::from(self);
+
+        let has_trailing_zero = name.last().map_or(false, |last| *last == 0);
+
+        if !has_trailing_zero {
+            name.push(0 as u8);
+        }
+
+        let handle = unsafe { logmsg::log_msg_get_value_handle(name.as_ptr() as *const i8) };
+        NVHandle(handle)
+    }
+}

--- a/syslog-ng-rs/syslog-ng-common/src/logmsg/test.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/logmsg/test.rs
@@ -1,0 +1,79 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use std::collections::BTreeMap;
+
+use super::LogMessage;
+use SYSLOG_NG_INITIALIZED;
+use syslog_ng_global_init;
+
+#[test]
+fn test_given_empty_log_msg_when_values_are_inserted_then_we_can_get_them_back() {
+    SYSLOG_NG_INITIALIZED.call_once(|| {
+        unsafe { syslog_ng_global_init(); }
+    });
+    let mut logmsg = LogMessage::new();
+    let expected_values = {
+        let mut values = BTreeMap::new();
+        values.insert(b"foo".to_vec(), b"bar".to_vec());
+        values.insert(b"qux".to_vec(), b"baz".to_vec());
+        values.insert(b"empty".to_vec(), b"".to_vec());
+        values
+    };
+
+    logmsg.insert("foo", b"bar");
+    logmsg.insert("qux", b"baz");
+    logmsg.insert("empty", b"");
+    assert_eq!(&expected_values, &logmsg.values());
+}
+
+#[test]
+fn test_given_empty_log_msg_when_a_not_inserted_key_is_looked_up_then_get_returns_none() {
+    SYSLOG_NG_INITIALIZED.call_once(|| {
+        unsafe { syslog_ng_global_init(); }
+    });
+    let mut logmsg = LogMessage::new();
+    logmsg.insert("foo", b"bar");
+    assert_eq!(None, logmsg.get("ham"));
+}
+
+#[test]
+fn test_log_msg_get_returns_the_expected_value() {
+    SYSLOG_NG_INITIALIZED.call_once(|| {
+        unsafe { syslog_ng_global_init(); }
+    });
+    let mut logmsg = LogMessage::new();
+    logmsg.insert("foo", b"bar");
+    let expected = b"bar";
+    let actual = logmsg.get("foo");
+    assert_eq!(Some(&expected[..]), actual);
+}
+
+#[test]
+fn test_byte_slices_can_be_used_as_names_in_log_message_insert() {
+    SYSLOG_NG_INITIALIZED.call_once(|| {
+        unsafe { syslog_ng_global_init(); }
+    });
+    let mut logmsg = LogMessage::new();
+    logmsg.insert(&b"foo"[..], b"bar");
+    let expected = b"bar";
+    let actual = logmsg.get("foo");
+    assert_eq!(Some(&expected[..]), actual);
+}
+
+#[test]
+fn test_set_tags_can_be_iterated_over_in_log_message() {
+    SYSLOG_NG_INITIALIZED.call_once(|| {
+        unsafe { syslog_ng_global_init(); }
+    });
+    let mut logmsg = LogMessage::new();
+    logmsg.set_tag(b"foo");
+    let expected = vec![b"foo".to_vec()];
+    let actual = logmsg.tags();
+    assert_eq!(expected, actual);
+}

--- a/syslog-ng-rs/syslog-ng-common/src/logparser.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/logparser.rs
@@ -1,0 +1,27 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use syslog_ng_sys;
+use Pipe;
+use LogPipe;
+use LogMessage;
+
+pub struct LogParser(*mut syslog_ng_sys::LogParser);
+
+impl LogParser {
+    pub fn wrap_raw(raw: *mut syslog_ng_sys::LogParser) -> LogParser {
+        LogParser(raw)
+    }
+}
+
+impl Pipe for LogParser {
+    fn forward(&mut self, msg: LogMessage) {
+        let mut logpipe = LogPipe(self.0 as *mut syslog_ng_sys::LogPipe);
+        logpipe.forward(msg)
+    }
+}

--- a/syslog-ng-rs/syslog-ng-common/src/logpipe.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/logpipe.rs
@@ -1,0 +1,21 @@
+use syslog_ng_sys;
+use LogMessage;
+
+use syslog_ng_sys::logpipe::__log_pipe_forward_msg;
+use syslog_ng_sys::LogPathOptions;
+
+pub trait Pipe {
+    fn forward(&mut self, msg: LogMessage);
+}
+
+pub struct LogPipe(pub *mut syslog_ng_sys::LogPipe);
+
+impl Pipe for LogPipe {
+    fn forward(&mut self, msg: LogMessage) {
+        let mut path_options = LogPathOptions::default();
+        path_options.ack_needed = 0;
+        unsafe {
+            __log_pipe_forward_msg(self.0 as *mut syslog_ng_sys::LogPipe, msg.into_raw(), &path_options);
+        }
+    }
+}

--- a/syslog-ng-rs/syslog-ng-common/src/logtemplate/mod.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/logtemplate/mod.rs
@@ -1,0 +1,93 @@
+use syslog_ng_sys;
+use syslog_ng_sys::logtemplate as sys;
+use glib_sys;
+use glib;
+use LogMessage;
+
+use GlobalConfig;
+
+use std::slice::from_raw_parts;
+use std::ffi::{CString, NulError};
+
+#[cfg(test)]
+mod tests;
+
+pub struct LogTemplate {
+    pub wrapped: *mut sys::LogTemplate,
+    buffer: *mut glib_sys::GString,
+}
+
+pub struct LogTemplateOptions(pub *mut sys::LogTemplateOptions);
+
+pub enum LogTimeZone {
+    Local = 0,
+    Send = 1,
+}
+
+pub enum Error {
+    Glib(glib::Error),
+    Nul(NulError)
+}
+
+impl From<NulError> for Error {
+    fn from(error: NulError) -> Error {
+        Error::Nul(error)
+    }
+}
+
+impl Error {
+    pub fn into_vec(self) -> Vec<u8> {
+        match self {
+            Error::Glib(error) => error.to_string().into(),
+            Error::Nul(error) => error.into_vec(),
+        }
+    }
+}
+
+impl LogTemplate {
+    fn new(cfg: &GlobalConfig) -> LogTemplate {
+        let raw_cfg = cfg.raw_ptr();
+        LogTemplate {
+            wrapped: unsafe { sys::log_template_new(raw_cfg, ::std::ptr::null()) },
+            buffer: unsafe { glib_sys::g_string_sized_new(128) },
+        }
+    }
+    pub fn compile(cfg: &GlobalConfig, content: &[u8]) -> Result<LogTemplate, Error> {
+        let template = LogTemplate::new(cfg);
+        let content = try!(CString::new(content));
+        let mut error = ::std::ptr::null_mut();
+        let result = unsafe { sys::log_template_compile(template.wrapped, content.as_ptr(), &mut error) };
+        if result != 0 {
+            Ok(template)
+        } else {
+            Err(Error::Glib(glib::Error::wrap(error)))
+        }
+    }
+
+    pub fn format(&mut self, msg: &LogMessage, options: Option<&LogTemplateOptions>, tz: LogTimeZone, seq_num: i32) -> &[u8] {
+        let options: *const sys::LogTemplateOptions = options.map_or(::std::ptr::null(), |options| options.0);
+        unsafe {
+            sys::log_template_format(self.wrapped, msg.0, options, tz as i32, seq_num, ::std::ptr::null(), self.buffer);
+            from_raw_parts((*self.buffer).str as *const u8, (*self.buffer).len)
+        }
+    }
+
+    pub fn format_with_context(&mut self, messages: &[LogMessage], options: Option<&LogTemplateOptions>, tz: LogTimeZone, seq_num: i32, context_id: &str) -> &[u8] {
+        let options: *const sys::LogTemplateOptions = options.map_or(::std::ptr::null(), |options| options.0);
+        let messages = messages.iter().map(|msg| msg.0 as *const syslog_ng_sys::LogMessage).collect::<Vec<*const syslog_ng_sys::LogMessage>>();
+        let context_id = CString::new(context_id).unwrap();
+        unsafe {
+            sys::log_template_format_with_context(self.wrapped, messages.as_ptr(), messages.len() as i32, options, tz as i32, seq_num, context_id.as_ptr(), self.buffer);
+            from_raw_parts((*self.buffer).str as *const u8, (*self.buffer).len)
+        }
+    }
+}
+
+impl Drop for LogTemplate {
+    fn drop(&mut self) {
+        unsafe {
+            sys::log_template_unref(self.wrapped);
+            glib_sys::g_string_free(self.buffer, 1 as glib_sys::gboolean);
+        };
+    }
+}

--- a/syslog-ng-rs/syslog-ng-common/src/logtemplate/tests.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/logtemplate/tests.rs
@@ -1,0 +1,59 @@
+use super::*;
+use GlobalConfig;
+use LogMessage;
+
+use SYSLOG_NG_INITIALIZED;
+use syslog_ng_global_init;
+
+#[test]
+fn test_template_can_be_created() {
+    SYSLOG_NG_INITIALIZED.call_once(|| {
+        unsafe { syslog_ng_global_init(); }
+    });
+    let cfg = GlobalConfig::new(0x0308);
+    let _ = LogTemplate::new(&cfg);
+}
+
+#[test]
+fn test_template_can_be_compiled() {
+    SYSLOG_NG_INITIALIZED.call_once(|| {
+        unsafe { syslog_ng_global_init(); }
+    });
+    let cfg = GlobalConfig::new(0x0308);
+    let _ = LogTemplate::compile(&cfg, b"literal").ok().unwrap();
+}
+
+#[test]
+fn test_invalid_template_cannot_be_compiled() {
+    SYSLOG_NG_INITIALIZED.call_once(|| {
+        unsafe { syslog_ng_global_init(); }
+    });
+    let cfg = GlobalConfig::new(0x0308);
+    let _ = LogTemplate::compile(&cfg, b"${unbalanced").err().unwrap();
+}
+
+#[test]
+fn test_log_message_can_be_formatted() {
+    SYSLOG_NG_INITIALIZED.call_once(|| {
+        unsafe { syslog_ng_global_init(); }
+    });
+    let cfg = GlobalConfig::new(0x0308);
+    let mut template = LogTemplate::compile(&cfg, b"${kittens}").ok().unwrap();
+    let mut msg = LogMessage::new();
+    msg.insert("kittens", b"2");
+    let formatted_msg = template.format(&msg, None, LogTimeZone::Local, 0);
+    assert_eq!(b"2", formatted_msg);
+}
+
+#[test]
+fn test_context_id_can_be_used() {
+    SYSLOG_NG_INITIALIZED.call_once(|| {
+        unsafe { syslog_ng_global_init(); }
+    });
+    let cfg = GlobalConfig::new(0x0308);
+    let mut template = LogTemplate::compile(&cfg, b"${CONTEXT_ID}").ok().unwrap();
+    let msg = LogMessage::new();
+    let messages = [msg];
+    let actual = template.format_with_context(&messages, None, LogTimeZone::Local, 0, "context-id");
+    assert_eq!(b"context-id", actual);
+}

--- a/syslog-ng-rs/syslog-ng-common/src/messages.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/messages.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use std::ffi::CString;
+use log::{LogLevel, LogLevelFilter};
+use syslog_ng_sys::messages;
+
+
+pub enum Msg {
+    _Fatal = 2,
+    Error = 3,
+    Warning = 4,
+    _Notice = 5,
+    Info = 6,
+    Debug = 7,
+}
+
+impl From<LogLevel> for Msg {
+    fn from(level: LogLevel) -> Msg {
+        match level {
+            LogLevel::Error => Msg::Error,
+            LogLevel::Warn => Msg::Warning,
+            LogLevel::Info => Msg::Info,
+            LogLevel::Debug => Msg::Debug,
+            LogLevel::Trace => Msg::Debug,
+        }
+    }
+}
+
+pub struct InternalMessageSender;
+
+impl InternalMessageSender {
+    pub fn create_and_send(severity: Msg, message: String) {
+        unsafe {
+            if messages::debug_flag != 0 {
+                let msg = CString::new(message).unwrap();
+                let prio = severity as i32;
+                let msg_event = messages::msg_event_create_from_desc(prio, msg.as_ptr());
+                messages::msg_event_suppress_recursions_and_send(msg_event);
+            }
+        };
+    }
+
+    pub fn level() -> LogLevelFilter {
+        if messages::trace_flag != 0 {
+            LogLevelFilter::Trace
+        } else if messages::debug_flag != 0 {
+            LogLevelFilter::Debug
+        } else {
+            LogLevelFilter::Info
+        }
+    }
+}

--- a/syslog-ng-rs/syslog-ng-common/src/mock.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/mock.rs
@@ -1,0 +1,18 @@
+use Pipe;
+use LogMessage;
+
+pub struct MockPipe{
+    pub forwarded_messages: Vec<LogMessage>
+}
+
+impl MockPipe {
+    pub fn new() -> MockPipe {
+        MockPipe{ forwarded_messages: Vec::new()}
+    }
+}
+
+impl Pipe for MockPipe {
+    fn forward(&mut self, msg: LogMessage) {
+        self.forwarded_messages.push(msg);
+    }
+}

--- a/syslog-ng-rs/syslog-ng-common/src/plugin.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/plugin.rs
@@ -1,0 +1,22 @@
+use GlobalConfig;
+
+use syslog_ng_sys;
+
+use std::ffi::CString;
+
+pub struct Plugin;
+
+impl Plugin {
+    pub fn load_module(name: &str, cfg: &mut GlobalConfig) -> bool {
+        let name = CString::new(name).unwrap();
+        let result =  unsafe {
+            syslog_ng_sys::plugin::plugin_load_module(name.as_ptr(),
+                                                      cfg.raw_ptr(),
+                                                      ::std::ptr::null_mut()) };
+        if result > 0 {
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/mod.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+#[macro_use]
+pub mod parser;

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
@@ -1,0 +1,101 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use LogMessage;
+use Pipe;
+
+mod option_error;
+mod proxy;
+
+pub use self::option_error::OptionError;
+pub use self::proxy::ParserProxy;
+use GlobalConfig;
+
+pub trait ParserBuilder<P: Pipe> {
+    type Parser: Parser<P>;
+    fn new(GlobalConfig) -> Self;
+    fn option(&mut self, _name: String, _value: String) {}
+    fn build(self) -> Result<Self::Parser, OptionError>;
+}
+
+pub trait Parser<P: Pipe>: Clone {
+    fn parse(&mut self, pipe: &mut P, msg: &mut LogMessage, input: &str) -> bool;
+}
+
+#[macro_export]
+macro_rules! parser_plugin {
+    ($name:ty) => {
+
+pub mod _parser_plugin {
+    use $crate::{c_int, c_char};
+    use $crate::LogMessage;
+    use $crate::LogParser;
+    use $crate::init_logger;
+    use $crate::ParserProxy;
+    use $crate::GlobalConfig;
+
+    use std::ffi::CStr;
+
+    use super::*;
+
+    #[no_mangle]
+    pub extern fn native_parser_proxy_init(this: &mut ParserProxy<$name>) -> c_int {
+        let res = this.init();
+
+        match res {
+            true => 1,
+            false => 0
+        }
+    }
+
+    #[no_mangle]
+    pub extern fn native_parser_proxy_free(_: Box<ParserProxy<$name>>) {
+    }
+
+    #[no_mangle]
+    pub extern fn native_parser_proxy_set_option(slf: &mut ParserProxy<$name>, key: *const c_char, value: *const c_char) {
+        let k: String = unsafe { CStr::from_ptr(key).to_owned().to_string_lossy().into_owned() };
+        let v: String = unsafe { CStr::from_ptr(value).to_owned().to_string_lossy().into_owned() };
+
+        slf.set_option(k, v);
+    }
+
+    #[no_mangle]
+    pub extern fn native_parser_proxy_process(this: &mut ParserProxy<$name>, parent: *mut $crate::sys::LogParser, msg: *mut $crate::sys::LogMessage, input: *const c_char) -> c_int {
+        let input = unsafe { CStr::from_ptr(input).to_str() };
+        let mut parent = LogParser::wrap_raw(parent);
+        let mut msg = LogMessage::wrap_raw(msg);
+        let result = match input {
+            Ok(input) => this.process(&mut parent, &mut msg, input),
+            Err(err) => {
+                error!("{}", err);
+                false
+            }
+        };
+
+        match result {
+            true => 1,
+            false => 0
+        }
+    }
+
+    #[no_mangle]
+    pub extern fn native_parser_proxy_new(cfg: *mut $crate::sys::GlobalConfig) -> Box<ParserProxy<$name>> {
+        init_logger();
+        let cfg = GlobalConfig::borrow(cfg);
+        Box::new(ParserProxy::new(cfg))
+    }
+
+    #[no_mangle]
+    pub extern fn native_parser_proxy_clone(slf: &ParserProxy<$name>) -> Box<ParserProxy<$name>> {
+        let cloned = (*slf).clone();
+        Box::new(cloned)
+    }
+}
+    }
+}

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/option_error.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/option_error.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum OptionError {
+    MissingRequiredOption(String),
+    InvalidValue {
+        option_name: String,
+        value: String,
+        expected_value: String,
+    },
+    VerbatimError(String)
+}
+
+impl OptionError {
+    pub fn missing_required_option<S: Into<String>>(option_name: S) -> OptionError {
+        OptionError::MissingRequiredOption(option_name.into())
+    }
+
+    pub fn invalid_value<S: Into<String>>(option_name: S,
+                                          value: S,
+                                          expected_value: S)
+                                          -> OptionError {
+        OptionError::InvalidValue {
+            option_name: option_name.into(),
+            value: value.into(),
+            expected_value: expected_value.into(),
+        }
+    }
+    pub fn verbatim_error(error_msg: String) -> OptionError {
+        OptionError::VerbatimError(error_msg)
+    }
+}
+
+use std::fmt::{Display, Error, Formatter};
+
+impl Display for OptionError {
+    fn fmt(&self, formatter: &mut Formatter) -> Result<(), Error> {
+        match *self {
+            OptionError::MissingRequiredOption(ref name) => {
+                formatter.write_fmt(format_args!("At least one required option is missing. \
+                                                  option_name={}",
+                                                 name))
+            }
+            OptionError::InvalidValue{ref option_name, ref value, ref expected_value} => {
+                formatter.write_fmt(format_args!("Invalid value in option. option_name={} \
+                                                  value={} expected_value={}",
+                                                 option_name,
+                                                 value,
+                                                 expected_value))
+            },
+            OptionError::VerbatimError(ref error_msg) => formatter.write_str(error_msg)
+        }
+    }
+}
+
+impl ::std::error::Error for OptionError {
+    fn description(&self) -> &str {
+        match *self {
+            OptionError::MissingRequiredOption(_) => "At least one required option is missing.",
+            OptionError::InvalidValue{..} => "Invalid value in option.",
+            OptionError::VerbatimError(..) => "Invalid value in option.",
+        }
+    }
+
+    fn cause(&self) -> Option<&::std::error::Error> {
+        match *self {
+            OptionError::MissingRequiredOption(_) => None,
+            OptionError::InvalidValue{..} => None,
+            OptionError::VerbatimError(..) => None,
+        }
+    }
+}

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
@@ -1,0 +1,64 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use LogMessage;
+use LogParser;
+use GlobalConfig;
+
+pub use proxies::parser::{OptionError, Parser, ParserBuilder};
+
+#[repr(C)]
+pub struct ParserProxy<B>
+    where B: ParserBuilder<LogParser>
+{
+    pub parser: Option<B::Parser>,
+    pub builder: Option<B>,
+}
+
+impl<B> ParserProxy<B> where B: ParserBuilder<LogParser>
+{
+    pub fn new(cfg: GlobalConfig) -> ParserProxy<B> {
+        ParserProxy {
+            parser: None,
+            builder: Some(B::new(cfg)),
+        }
+    }
+
+    pub fn init(&mut self) -> bool {
+        let builder = self.builder.take().expect("Called init when builder was not set");
+        match builder.build() {
+            Ok(parser) => {
+                self.parser = Some(parser);
+                true
+            }
+            Err(error) => {
+                error!("Error: {:?}", error);
+                false
+            }
+        }
+    }
+
+    pub fn set_option(&mut self, name: String, value: String) {
+        let builder = self.builder.as_mut().expect("Failed to get builder on a ParserProxy");
+        builder.option(name, value);
+    }
+
+    pub fn process(&mut self, parent: &mut LogParser, msg: &mut LogMessage, input: &str) -> bool {
+        self.parser
+            .as_mut()
+            .expect("Called process on a non-existing Rust parser")
+            .parse(parent, msg, input)
+    }
+}
+
+impl<B> Clone for ParserProxy<B> where B: ParserBuilder<LogParser> {
+    fn clone(&self) -> ParserProxy<B> {
+        // it makes no sense to clone() the builder
+        ParserProxy {parser: self.parser.clone(), builder: None}
+    }
+}

--- a/syslog-ng-rs/syslog-ng-common/src/sys.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/sys.rs
@@ -1,0 +1,22 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+pub use syslog_ng_sys::LogMessage;
+pub use syslog_ng_sys::LogParser;
+pub use syslog_ng_sys::GlobalConfig;
+
+pub mod logmsg {
+    pub use syslog_ng_sys::logmsg::log_msg_registry_init;
+    pub use syslog_ng_sys::logmsg::log_msg_registry_deinit;
+    pub use syslog_ng_sys::logmsg::log_tags_global_init;
+}
+
+pub mod logtemplate {
+    pub use syslog_ng_sys::logtemplate::log_template_global_init;
+    pub use syslog_ng_sys::logtemplate::log_template_global_deinit;
+}

--- a/syslog-ng-rs/syslog-ng-common/tests/dummy-parser.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/dummy-parser.rs
@@ -1,0 +1,77 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+#[macro_use]
+extern crate syslog_ng_common;
+#[macro_use]
+extern crate log;
+
+use std::marker::PhantomData;
+
+pub struct DummyParser<P: Pipe>(PhantomData<P>);
+
+impl<P: Pipe> Clone for DummyParser<P> {
+    fn clone(&self) -> DummyParser<P> {
+        DummyParser(self.0.clone())
+    }
+}
+
+pub struct DummyParserBuilder<P: Pipe>(PhantomData<P>);
+
+use syslog_ng_common::LogMessage;
+use syslog_ng_common::{Parser, ParserBuilder, OptionError, Pipe, GlobalConfig};
+
+impl<P: Pipe> ParserBuilder<P> for DummyParserBuilder<P> {
+    type Parser = DummyParser<P>;
+    fn new(_: GlobalConfig) -> Self {
+        DummyParserBuilder(PhantomData)
+    }
+    fn option(&mut self, name: String, value: String) {
+        debug!("Setting option: {}={}", name, value);
+    }
+    fn build(self) -> Result<Self::Parser, OptionError> {
+        debug!("Building Rust parser");
+        Ok(DummyParser(PhantomData))
+    }
+}
+
+impl<P: Pipe> Parser<P> for DummyParser<P> {
+    fn parse(&mut self, _: &mut P, message: &mut LogMessage, input: &str) -> bool {
+        debug!("Processing input in Rust Parser: {}", input);
+        message.insert("input", input);
+        true
+    }
+}
+
+// this verifies that the macro can be expanded
+parser_plugin!(DummyParserBuilder<LogParser>);
+
+use syslog_ng_common::{SYSLOG_NG_INITIALIZED, syslog_ng_global_init};
+
+struct DummyPipe;
+
+impl Pipe for DummyPipe {
+    fn forward(&mut self, _: LogMessage) {}
+}
+
+#[test]
+fn test_given_parser_implementation_when_it_receives_a_message_then_it_adds_a_specific_key_value_pair_to_it
+    () {
+    SYSLOG_NG_INITIALIZED.call_once(|| {
+        unsafe { syslog_ng_global_init(); }
+    });
+    let cfg = GlobalConfig::new(0x0308);
+    let builder = DummyParserBuilder::<DummyPipe>::new(cfg);
+    let mut parser = builder.build().ok().expect("Failed to build DummyParser");
+    let mut msg = LogMessage::new();
+    let input = "The quick brown ...";
+    let mut pipe = DummyPipe;
+    let result = parser.parse(&mut pipe, &mut msg, input);
+    assert!(result);
+    assert_eq!(msg.get("input").unwrap(), input);
+}

--- a/syslog-ng-rs/syslog-ng-common/tests/template_functions.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/template_functions.rs
@@ -1,0 +1,34 @@
+extern crate syslog_ng_common;
+
+use syslog_ng_common::{GlobalConfig, LogMessage, SYSLOG_NG_INITIALIZED, syslog_ng_global_init, LogTemplate, LogTimeZone, Plugin};
+
+fn test_log_message_context_can_be_formatted(cfg: &GlobalConfig) {
+    let mut template = LogTemplate::compile(&cfg, br#"$(grep ("${bar}" == "BAR") ${baz})"#).ok().unwrap();
+    let mut msg_1 = LogMessage::new();
+    let mut msg_2 = LogMessage::new();
+    msg_1.insert("foo", b"FOO");
+    msg_1.insert("bar", b"BAR");
+    msg_1.insert("baz", b"1");
+    msg_2.insert("bar", b"BAR");
+    msg_2.insert("baz", b"2");
+    let messages = [msg_1, msg_2];
+    let formatted_msg = template.format_with_context(&messages, None, LogTimeZone::Local, 0, "dummy");
+    assert_eq!(b"1,2", formatted_msg);
+}
+
+fn test_empty_log_message_context_can_be_formatted(cfg: &GlobalConfig) {
+    let mut template = LogTemplate::compile(&cfg, br#"$(grep ("${bar}" == "BAR") ${baz})"#).ok().unwrap();
+    let messages = [];
+    let formatted_msg = template.format_with_context(&messages, None, LogTimeZone::Local, 0, "dummy");
+    assert_eq!(b"", formatted_msg);
+}
+
+fn main() {
+    SYSLOG_NG_INITIALIZED.call_once(|| {
+        unsafe { syslog_ng_global_init(); }
+    });
+    let mut cfg = GlobalConfig::new(0x0308);
+    Plugin::load_module("basicfuncs", &mut cfg);
+    test_log_message_context_can_be_formatted(&cfg);
+    test_empty_log_message_context_can_be_formatted(&cfg);
+}

--- a/syslog-ng-rs/syslog-ng-sys/.gitignore
+++ b/syslog-ng-rs/syslog-ng-sys/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/syslog-ng-rs/syslog-ng-sys/Cargo.toml
+++ b/syslog-ng-rs/syslog-ng-sys/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "syslog-ng-sys"
+version = "0.3.0"
+authors = ["Tibor Benke <ihrwein@gmail.com>"]
+build = "build.rs"
+links = "syslog-ng"
+homepage = "https://github.com/ihrwein/syslog-ng-rs"
+repository = "https://github.com/ihrwein/syslog-ng-rs"
+keywords = ["syslog-ng"]
+description = "Low level bindings for syslog-ng"
+license = "MIT/Apache-2.0"
+
+[lib]
+name = "syslog_ng_sys"
+
+[dependencies]
+libc = "0.2"
+log = "0.3"
+glib-sys = "0.3.0"
+
+[build-dependencies]
+pkg-config = "0.3"

--- a/syslog-ng-rs/syslog-ng-sys/build.rs
+++ b/syslog-ng-rs/syslog-ng-sys/build.rs
@@ -1,0 +1,24 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+extern crate pkg_config;
+
+fn main() {
+    let res = pkg_config::find_library("syslog-ng");
+    match res {
+        Ok(value) => {
+            for dir in value.link_paths {
+                println!("cargo:rustc-link-search=native={:?}", dir);
+            }
+            println!("cargo:rustc-link-lib=dylib=syslog-ng");
+        },
+        Err(err) => {
+            println!("libsyslog-ng.so is not found by pkg-config: {}", err);
+        }
+    }
+}

--- a/syslog-ng-rs/syslog-ng-sys/src/cfg.rs
+++ b/syslog-ng-rs/syslog-ng-sys/src/cfg.rs
@@ -1,0 +1,20 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use ::types::*;
+
+pub enum GlobalConfig {}
+
+#[link(name = "syslog-ng")]
+extern "C" {
+    pub fn cfg_get_user_version(cfg: *const GlobalConfig) -> c_int;
+    pub fn cfg_get_parsed_version(cfg: *const GlobalConfig) -> c_int;
+    pub fn cfg_get_filename(cfg: *const GlobalConfig) -> *const c_char;
+    pub fn cfg_new(version: c_int) -> *mut GlobalConfig;
+    pub fn cfg_free(slf: *mut GlobalConfig);
+}

--- a/syslog-ng-rs/syslog-ng-sys/src/lib.rs
+++ b/syslog-ng-rs/syslog-ng-sys/src/lib.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+extern crate libc;
+#[macro_use]
+extern crate log;
+extern crate glib_sys;
+
+pub mod types;
+pub mod logmsg;
+pub mod cfg;
+pub mod messages;
+pub mod logparser;
+pub mod logpipe;
+pub mod logtemplate;
+pub mod plugin;
+pub mod resolved_configurable_paths;
+
+pub use types::*;
+pub use logmsg::*;
+pub use cfg::*;
+pub use messages::*;
+pub use logparser::LogParser;
+pub use logpipe::{LogPathOptions, LogPipe};
+pub use plugin::Plugin;

--- a/syslog-ng-rs/syslog-ng-sys/src/logmsg.rs
+++ b/syslog-ng-rs/syslog-ng-sys/src/logmsg.rs
@@ -1,0 +1,60 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use ::types::*;
+
+pub enum LogMessage {}
+pub type NVHandle = u32;
+pub type LogTagId = u16;
+pub type NVTableForeachFunc = extern "C" fn(// handle:
+                                            NVHandle, // name:
+                                            *const c_char, // value:
+                                            *const c_char, // value_len:
+                                            ssize_t, // user_data:
+                                            *mut c_void)
+                                            -> bool;
+pub type LogMessageTagsForeachFunc = extern "C" fn(// msg:
+                                                   *const LogMessage, // tag_id:
+                                                   LogTagId, // name:
+                                                   *const c_char, // user_data:
+                                                   *mut c_void)
+                                                   -> bool;
+
+#[link(name = "syslog-ng")]
+extern "C" {
+    pub fn log_msg_unref(m: *mut LogMessage) -> ();
+    pub fn log_msg_ref(m: *mut LogMessage) -> *mut LogMessage;
+    pub fn log_msg_get_value_handle(value_name: *const c_char) -> NVHandle;
+    pub fn __log_msg_get_value(m: *const LogMessage,
+                               handle: NVHandle,
+                               value_len: *mut ssize_t)
+                               -> *const c_char;
+    pub fn __log_msg_get_value_by_name(m: *const LogMessage,
+                                       name: *const c_char,
+                                       value_len: *mut ssize_t)
+                                       -> *const c_char;
+    pub fn __log_msg_set_value_by_name(msg: *mut LogMessage,
+                                       name: *const c_char,
+                                       value: *const c_char,
+                                       value_length: ssize_t);
+    pub fn log_msg_set_tag_by_name(msg: *mut LogMessage, name: *const c_char);
+    pub fn log_msg_values_foreach(msg: *const LogMessage,
+                                  func: NVTableForeachFunc,
+                                  user_data: *mut c_void);
+    pub fn log_msg_new_empty() -> *mut LogMessage;
+    pub fn log_msg_tags_foreach(msg: *const LogMessage,
+                                callback: LogMessageTagsForeachFunc,
+                                user_data: *mut c_void);
+    pub fn log_msg_registry_init();
+    pub fn log_msg_registry_deinit();
+    pub fn log_msg_set_value(msg: *mut LogMessage,
+                             handle: NVHandle,
+                             value: *const c_char,
+                             value_length: ssize_t);
+    pub fn log_tags_global_init();
+}

--- a/syslog-ng-rs/syslog-ng-sys/src/logparser.rs
+++ b/syslog-ng-rs/syslog-ng-sys/src/logparser.rs
@@ -1,0 +1,9 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+pub enum LogParser {}

--- a/syslog-ng-rs/syslog-ng-sys/src/logpipe.rs
+++ b/syslog-ng-rs/syslog-ng-sys/src/logpipe.rs
@@ -1,0 +1,22 @@
+use LogMessage;
+use types::c_int;
+
+#[repr(C)]
+pub struct LogPathOptions {
+    pub ack_needed: c_int,
+    pub flow_control_requested: c_int,
+    pub matched: *mut c_int
+}
+
+impl Default for LogPathOptions {
+    fn default() -> LogPathOptions {
+        LogPathOptions {ack_needed: 0, flow_control_requested: 0, matched: ::std::ptr::null_mut()}
+    }
+}
+
+pub enum LogPipe {}
+
+#[link(name = "syslog-ng")]
+extern "C" {
+    pub fn __log_pipe_forward_msg(slf: *mut LogPipe, msg: *mut LogMessage, path_options: *const LogPathOptions);
+}

--- a/syslog-ng-rs/syslog-ng-sys/src/logtemplate.rs
+++ b/syslog-ng-rs/syslog-ng-sys/src/logtemplate.rs
@@ -1,0 +1,38 @@
+use glib_sys::{GError, GString};
+
+use types::{c_int, c_char, c_void};
+use GlobalConfig;
+use LogMessage;
+
+pub const LTZ_LOCAL: i32 = 0;
+pub const LTZ_SEND: i32 = 1;
+pub const LTZ_MAX: i32 = 2;
+
+// this could be expanded but it's best to keep it as an opaque pointer
+pub enum LogTemplate {}
+// this should be expanded, but log_template_format() can handle a NULL opts
+pub enum LogTemplateOptions {}
+
+#[link(name = "syslog-ng")]
+extern "C" {
+   pub fn log_template_compile(slf: *mut LogTemplate, template: *const c_char, error: *mut *mut GError) -> c_int;
+   pub fn log_template_new(cfg: *const GlobalConfig, name: *const c_char) -> *mut LogTemplate;
+   pub fn log_template_format(slf: *const LogTemplate,
+                              lm: *const LogMessage,
+                              opts: *const LogTemplateOptions,
+                              tz: c_int,
+                              seq_num: i32,
+                              context_id: *const c_char,
+                              result: *mut GString) -> c_void;
+    pub fn log_template_unref(s: *mut LogTemplate);
+    pub fn log_template_global_init();
+    pub fn log_template_global_deinit();
+    pub fn log_template_format_with_context(slf: *const LogTemplate,
+                                            messages: *const *const LogMessage,
+                                            num_messages: c_int,
+                                            opts: *const LogTemplateOptions,
+                                            tz: c_int,
+                                            seq_num: i32,
+                                            context_id: *const c_char,
+                                            result: *mut GString) -> c_void;
+}

--- a/syslog-ng-rs/syslog-ng-sys/src/messages.rs
+++ b/syslog-ng-rs/syslog-ng-sys/src/messages.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+use ::types::*;
+
+pub enum EVTREC {}
+
+#[link(name = "syslog-ng")]
+extern "C" {
+    pub fn msg_event_create_from_desc(prio: i32, desc: *const c_char) -> *mut EVTREC;
+    pub fn msg_event_suppress_recursions_and_send(e: *mut EVTREC);
+    pub static debug_flag: c_int;
+    pub static trace_flag: c_int;
+}

--- a/syslog-ng-rs/syslog-ng-sys/src/plugin.rs
+++ b/syslog-ng-rs/syslog-ng-sys/src/plugin.rs
@@ -1,0 +1,10 @@
+use types::{c_char, c_int};
+use GlobalConfig;
+
+pub enum Plugin {}
+pub enum CfgArgs {}
+
+#[link(name = "syslog-ng")]
+extern "C" {
+   pub fn plugin_load_module(module_name: *const c_char, cfg: *mut GlobalConfig, cfg_args: *mut CfgArgs) -> c_int;
+}

--- a/syslog-ng-rs/syslog-ng-sys/src/resolved_configurable_paths.rs
+++ b/syslog-ng-rs/syslog-ng-sys/src/resolved_configurable_paths.rs
@@ -1,0 +1,15 @@
+use c_char;
+
+#[repr(C)]
+pub struct ResolvedConfigurablePaths {
+  cfgfilename : *const c_char,
+  persist_file : *const c_char,
+  ctlfilename : *const c_char,
+  initial_module_path : *const c_char,
+}
+
+#[link(name = "syslog-ng")]
+extern "C" {
+    pub fn resolved_configurable_paths_init(slf: *mut ResolvedConfigurablePaths);
+    pub static mut resolvedConfigurablePaths: ResolvedConfigurablePaths;
+}

--- a/syslog-ng-rs/syslog-ng-sys/src/types.rs
+++ b/syslog-ng-rs/syslog-ng-sys/src/types.rs
@@ -1,0 +1,9 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+pub use libc::{c_void, c_char, c_int, c_ulong, ssize_t};


### PR DESCRIPTION
This PR embeds the [syslog-ng-rs](https://github.com/ihrwein/syslog-ng-rs) crate as a subdirectory here.

The last 4 commits are new ones.