### PR TITLE
Update uuid crate in correlation parser

### DIFF
--- a/correlation-parser/correlation/Cargo.toml
+++ b/correlation-parser/correlation/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 maplit = "0.1"
-uuid = "0.1"
+uuid = "^0.2.2"
 serde = "0.7"
 serde_json = "0.7"
 serde_yaml = "0.2"
@@ -20,5 +20,5 @@ env_logger = "0.3.1"
 clippy = {version = "*", optional = true}
 
 [features]
-default=[]
+default=["uuid/v4", "uuid/serde"]
 nightly = ["clippy"]

--- a/correlation-parser/correlation/src/config/action/message/mod.rs
+++ b/correlation-parser/correlation/src/config/action/message/mod.rs
@@ -55,7 +55,7 @@ impl<T> MessageAction<T> {
     }
 
     fn execute<E>(&self, state: &State<E>, context: &BaseContext<E, T>, responder: &mut VecDeque<Alert<E>>) where E: Event, T: Template<Event=E> {
-        let context_id = context.uuid.to_hyphenated_string();
+        let context_id = context.uuid.hyphenated().to_string();
         let mut message = Vec::new();
         self.message.format_with_context(state.messages(), &context_id, &mut message);
         let mut event = E::new(&self.uuid.as_bytes(), &message);

--- a/correlation-parser/correlation/src/config/deser.rs
+++ b/correlation-parser/correlation/src/config/deser.rs
@@ -61,27 +61,6 @@ impl Deserialize for Field {
 
 struct ContextVisitor<T> (PhantomData<T>);
 
-impl<T> ContextVisitor<T> {
-    fn parse_uuid<V>(uuid: Option<String>) -> Result<Uuid, V::Error>
-        where V: MapVisitor
-    {
-        match uuid {
-            Some(value) => {
-                match Uuid::parse_str(&value) {
-                    Ok(uuid) => Ok(uuid),
-                    Err(err) => {
-                        Err(Error::custom(format!("Failed to parse field 'uuid': uuid={} \
-                                                    error={}",
-                                                   value,
-                                                   err)))
-                    }
-                }
-            }
-            None => Err(Error::missing_field("uuid")),
-        }
-    }
-}
-
 impl<T> Visitor for ContextVisitor<T> where T: Deserialize {
     type Value = ContextConfig<T>;
 
@@ -89,7 +68,7 @@ impl<T> Visitor for ContextVisitor<T> where T: Deserialize {
         where V: MapVisitor
     {
         let mut name = None;
-        let mut uuid: Option<String> = None;
+        let mut uuid: Option<Uuid> = None;
         let mut conditions = None;
         let mut context_id: Option<Vec<String>> = None;
         let mut actions = None;
@@ -108,7 +87,12 @@ impl<T> Visitor for ContextVisitor<T> where T: Deserialize {
 
         try!(visitor.end());
 
-        let uuid = try!(ContextVisitor::<T>::parse_uuid::<V>(uuid));
+        let uuid = if let Some(uuid) = uuid {
+            uuid
+        } else {
+            return Err(V::Error::missing_field("uuid"));
+        };
+
         let actions = actions.unwrap_or_default();
         let conditions = try!(conditions.ok_or(V::Error::missing_field("conditions")));
 

--- a/correlation-parser/correlation/src/config/deser.rs
+++ b/correlation-parser/correlation/src/config/deser.rs
@@ -268,4 +268,17 @@ mod test {
         "#;
         let _ = from_str::<ContextConfig<String>>(text).err().unwrap();
     }
+
+    #[test]
+    fn test_given_config_context_when_it_invalid_uuid_then_we_dont_panic() {
+        let text = r#"
+        {
+            "uuid": "231231212212423424324323477343246663",
+            "conditions": {
+                "timeout": 100
+            }
+        }
+        "#;
+        let _ = from_str::<ContextConfig<String>>(text).err().unwrap();
+    }
 }

--- a/correlation-parser/correlation/src/context/context_map.rs
+++ b/correlation-parser/correlation/src/context/context_map.rs
@@ -124,7 +124,6 @@ mod tests {
     use context::{Context, LinearContext};
     use uuid::Uuid;
     use std::time::Duration;
-    use Event;
     use Message;
     use test_utils::{MockTemplate, BaseContextBuilder};
 

--- a/correlation-parser/correlation/src/correlator/test.rs
+++ b/correlation-parser/correlation/src/correlator/test.rs
@@ -132,7 +132,7 @@ fn test_given_correlator_when_it_is_built_from_json_then_we_get_the_expected_cor
     }
     let context = contexts.remove(0);
     assert_eq!(Some(&expected_name), context.name.as_ref());
-    assert_eq!(&expected_uuid, &context.uuid.to_hyphenated_string());
+    assert_eq!(&expected_uuid, &context.uuid.hyphenated().to_string());
 }
 
 #[test]

--- a/correlation-parser/correlation/src/test_utils/template.rs
+++ b/correlation-parser/correlation/src/test_utils/template.rs
@@ -1,5 +1,4 @@
 use Template;
-use Event;
 use TemplateFactory;
 use Message;
 use CompileError;


### PR DESCRIPTION
I forget to open a PR from these changes.

This PR fixes a potential `panic!` by updating uuid crate to at least `0.2.2`.