### PR TITLE
Impl deinit() for parsers

### DIFF
--- a/actiondb-parser/Cargo.toml
+++ b/actiondb-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actiondb-parser"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Tibor Benke <tibor.benke@balabit.com>"]
 build = "build.rs"
 homepage = "https://github.com/ihrwein/actiondb-parser"

--- a/actiondb-parser/src/lib.rs
+++ b/actiondb-parser/src/lib.rs
@@ -98,15 +98,6 @@ impl<M, P> Parser<P> for ActiondbParser<M> where P: Pipe, M: Matcher + Clone {
     }
 }
 
-impl<M> Clone for ActiondbParser<M> where M: Matcher + Clone {
-    fn clone(&self) -> ActiondbParser<M> {
-        ActiondbParser {
-            matcher: self.matcher.clone(),
-            formatter: self.formatter.clone(),
-        }
-    }
-}
-
 
 // You can change the matcher implementation by uncommening these lines
 // and commenting out the last lines.

--- a/correlation-parser/Cargo.toml
+++ b/correlation-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "correlation-parser"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Tibor Benke <ihrwein@gmail.com>"]
 build = "build.rs"
 

--- a/correlation-parser/src/lib.rs
+++ b/correlation-parser/src/lib.rs
@@ -120,7 +120,7 @@ impl<P, E, T, TF, TM> ParserBuilder<P> for CorrelationParserBuilder<P, E, T, TF,
 
 pub struct CorrelationParser<E, T, TM> where E: 'static + Event + Send, T: 'static + Template<Event=E>, TM: Timer<E, T> {
     correlator: Arc<Mutex<Correlator<E, T>>>,
-    formatter: MessageFormatter,
+    _formatter: MessageFormatter,
     pub timer: Arc<TM>
 }
 
@@ -128,7 +128,7 @@ impl<E, T, TM> CorrelationParser<E, T, TM> where E: Event + Send, T: Template<Ev
     pub fn new(correlator: Arc<Mutex<Correlator<E, T>>>, formatter: MessageFormatter, timer: Arc<TM>) -> CorrelationParser<E, T, TM> {
         CorrelationParser {
             correlator: correlator,
-            formatter: formatter,
+            _formatter: formatter,
             timer: timer
         }
     }

--- a/correlation-parser/src/lib.rs
+++ b/correlation-parser/src/lib.rs
@@ -125,17 +125,6 @@ pub struct CorrelationParser<E, T, TM> where E: 'static + Event + Send, T: 'stat
     pub timer: Arc<TM>
 }
 
-impl<E, T, TM> Clone for CorrelationParser<E, T, TM> where E: Event + Send, T: Template<Event=E>, TM: Timer<E, T> {
-    fn clone(&self) -> CorrelationParser<E, T, TM> {
-        CorrelationParser {
-            correlator: self.correlator.clone(),
-            formatter: self.formatter.clone(),
-            delta: self.delta.clone(),
-            timer: self.timer.clone()
-        }
-    }
-}
-
 impl<E, T, TM> CorrelationParser<E, T, TM> where E: Event + Send, T: Template<Event=E>, TM: Timer<E, T> {
     pub fn new(correlator: Arc<Mutex<Correlator<E, T>>>, formatter: MessageFormatter, delta: Duration, timer: Arc<TM>) -> CorrelationParser<E, T, TM> {
         CorrelationParser {

--- a/correlation-parser/src/lib.rs
+++ b/correlation-parser/src/lib.rs
@@ -38,7 +38,7 @@ pub trait Timer<E, T> where E: Event + Send, T: Template<Event=E> {
 pub struct CorrelationParserBuilder<P, E, T, TF, TM> where P: Pipe, E: 'static + Event + Send, T: 'static + Template<Event=E>, TF: TemplateFactory<E, Template=T>, TM: Timer<E, T> {
     correlator: Option<Correlator<E, T>>,
     formatter: MessageFormatter,
-    template_factory: TF,
+    template_factory: Arc<TF>,
     delta: Option<Duration>,
     _marker: PhantomData<(P, E, T, TF, TM)>
 }
@@ -91,7 +91,7 @@ impl<P, E, T, TF, TM> ParserBuilder<P> for CorrelationParserBuilder<P, E, T, TF,
         CorrelationParserBuilder {
             correlator: None,
             formatter: MessageFormatter::new(),
-            template_factory: TF::from(cfg),
+            template_factory: Arc::new(TF::from(cfg)),
             delta: Some(Duration::from_millis(1000)),
             _marker: PhantomData
         }

--- a/correlation-parser/src/lib.rs
+++ b/correlation-parser/src/lib.rs
@@ -74,6 +74,17 @@ impl<P, E, T, TF, TM> CorrelationParserBuilder<P, E, T, TF, TM> where P: Pipe, E
     }
 }
 
+impl<P, E, T, TF, TM> Clone for CorrelationParserBuilder<P, E, T, TF, TM> where P: Pipe, E: 'static + Event + Into<LogMessage> + Send, T: 'static + Template<Event=E>, TF: TemplateFactory<E, Template=T> + From<GlobalConfig>, TM: Timer<E, T> {
+    fn clone(&self) -> Self {
+        CorrelationParserBuilder {
+            contexts: self.contexts.clone(),
+            formatter: self.formatter.clone(),
+            template_factory: self.template_factory.clone(),
+            delta: self.delta.clone(),
+            _marker: PhantomData
+        }
+    }
+}
 impl<P, E, T, TF, TM> ParserBuilder<P> for CorrelationParserBuilder<P, E, T, TF, TM> where P: Pipe, E: 'static + Event + Into<LogMessage> + Send, T: 'static + Template<Event=E>, TF: TemplateFactory<E, Template=T> + From<GlobalConfig>, TM: Timer<E, T> {
     type Parser = CorrelationParser<E, T, TM>;
     fn new(cfg: GlobalConfig) -> Self {

--- a/correlation-parser/src/lib.rs
+++ b/correlation-parser/src/lib.rs
@@ -114,23 +114,21 @@ impl<P, E, T, TF, TM> ParserBuilder<P> for CorrelationParserBuilder<P, E, T, TF,
         let correlator = try!(correlator.ok_or(OptionError::missing_required_option(options::CONTEXTS_FILE)));
         let delta = try!(delta.ok_or(OptionError::missing_required_option(options::DELTA)));
         let timer = Arc::new(TM::new(delta, correlator.clone()));
-        Ok(CorrelationParser::new(correlator, formatter, delta, timer))
+        Ok(CorrelationParser::new(correlator, formatter, timer))
     }
 }
 
 pub struct CorrelationParser<E, T, TM> where E: 'static + Event + Send, T: 'static + Template<Event=E>, TM: Timer<E, T> {
     correlator: Arc<Mutex<Correlator<E, T>>>,
-    delta: Duration,
     formatter: MessageFormatter,
     pub timer: Arc<TM>
 }
 
 impl<E, T, TM> CorrelationParser<E, T, TM> where E: Event + Send, T: Template<Event=E>, TM: Timer<E, T> {
-    pub fn new(correlator: Arc<Mutex<Correlator<E, T>>>, formatter: MessageFormatter, delta: Duration, timer: Arc<TM>) -> CorrelationParser<E, T, TM> {
+    pub fn new(correlator: Arc<Mutex<Correlator<E, T>>>, formatter: MessageFormatter, timer: Arc<TM>) -> CorrelationParser<E, T, TM> {
         CorrelationParser {
             correlator: correlator,
             formatter: formatter,
-            delta: delta,
             timer: timer
         }
     }

--- a/correlation-parser/src/lib.rs
+++ b/correlation-parser/src/lib.rs
@@ -31,6 +31,8 @@ pub const CLASSIFIER_CLASS: &'static [u8] = b".classifier.class";
 
 pub trait Timer<E, T> where E: Event + Send, T: Template<Event=E> {
     fn new(delta: Duration, correlator: Arc<Mutex<Correlator<E, T>>>) -> Self;
+    fn start(&self) {}
+    fn stop(&self) {}
 }
 
 pub struct CorrelationParserBuilder<P, E, T, TF, TM> where P: Pipe, E: 'static + Event + Send, T: 'static + Template<Event=E>, TF: TemplateFactory<E, Template=T>, TM: Timer<E, T> {

--- a/correlation-parser/src/lib.rs
+++ b/correlation-parser/src/lib.rs
@@ -196,6 +196,16 @@ impl<P, E, T, TM> Parser<P> for CorrelationParser<E, T, TM> where P: Pipe, E: Ev
             }
         }
     }
+
+    fn init(&mut self) -> bool {
+        self.timer.start();
+        true
+    }
+
+    fn deinit(&mut self) -> bool {
+        self.timer.stop();
+        true
+    }
 }
 
 parser_plugin!(CorrelationParserBuilder<LogParser, LogEvent, LogTemplate, LogTemplateFactory, Watchdog>);

--- a/correlation-parser/src/timer.rs
+++ b/correlation-parser/src/timer.rs
@@ -37,16 +37,15 @@ impl Watchdog {
                         Err(TryRecvError::Empty) => (),
                     }
                 } else {
-                    thread::sleep(delta);
-
                     match rx.try_recv() {
                         Ok(ControlEvent::Stop) | Err(TryRecvError::Disconnected) => break,
                         Ok(ControlEvent::Park) => { is_parking = true; }
                         Ok(ControlEvent::UnPark) => { is_parking = false; }
-                        Err(TryRecvError::Empty) => (),
+                        Err(TryRecvError::Empty) => {
+                            cb();
+                            thread::sleep(delta);
+                        }
                     }
-
-                    cb();
                 }
             }
         });
@@ -55,7 +54,6 @@ impl Watchdog {
             sender: tx,
             _join_handle: join_handle,
         }
-
     }
 }
 

--- a/correlation-parser/src/timer.rs
+++ b/correlation-parser/src/timer.rs
@@ -79,6 +79,8 @@ impl<E, T> Timer<E, T> for Watchdog where E: Event + Send, T: Template<Event=E> 
 
 impl Drop for Watchdog {
     fn drop(&mut self) {
+        let _ = self.sender.send(ControlEvent::UnPark);
+        self._join_handle.thread().unpark();
         let _ = self.sender.send(ControlEvent::Stop);
     }
 }

--- a/correlation-parser/tests/timer.rs
+++ b/correlation-parser/tests/timer.rs
@@ -1,0 +1,37 @@
+extern crate correlation_parser;
+
+use correlation_parser::{Timer, Watchdog};
+use correlation_parser::mock::{MockEvent, MockLogTemplate};
+
+use std::time::Duration;
+use std::sync::{Arc, Mutex};
+
+fn assert_callback_called(cb_interval: Duration, iter_count: u32, acceptable_bias: u32) {
+    let counter = Arc::new(Mutex::new(0));
+
+    let cloned_counter = counter.clone();
+    let timer = Watchdog::schedule(cb_interval, move || {
+        if let Ok(mut guard) = cloned_counter.lock() {
+            *guard += 1;
+        }
+    });
+
+    Timer::<MockEvent, MockLogTemplate>::start(&timer);
+    ::std::thread::sleep(cb_interval * iter_count);
+    Timer::<MockEvent, MockLogTemplate>::stop(&timer);
+
+    if let Ok(guard) = counter.lock() {
+        let less = *guard < (iter_count - acceptable_bias);
+        let greater = *guard > (iter_count + acceptable_bias);
+        let in_middle = !less && !greater;
+        assert!(in_middle);
+    } else {
+        unreachable!();
+    };
+}
+
+#[test]
+fn test_watchdog_calls_the_provided_callback_after_it_is_started() {
+    assert_callback_called(Duration::from_millis(50), 6, 1);
+    assert_callback_called(Duration::from_millis(50), 60, 5);
+}

--- a/correlation-parser/tests/timer.rs
+++ b/correlation-parser/tests/timer.rs
@@ -41,3 +41,59 @@ fn test_watchdog_calls_the_provided_callback_after_it_is_started() {
     assert_callback_called(Duration::from_millis(50), 6, 1);
     assert_callback_called(Duration::from_millis(50), 60, 5);
 }
+
+#[test]
+fn test_timer_is_started_after_start_call() {
+    let cb_interval = Duration::from_millis(50);
+    let (counter, timer) = create_counter_and_timer(cb_interval);
+
+    ::std::thread::sleep(cb_interval * 2);
+    assert_eq!(*counter.lock().unwrap(), 0);
+
+    Timer::<MockEvent, MockLogTemplate>::start(&timer);
+    // wait some deltas to let the timer thread start and increment the counter
+    ::std::thread::sleep(cb_interval * 2);
+    assert!(*counter.lock().unwrap() > 0);
+}
+
+#[test]
+fn test_timer_is_stopped_after_stop_call() {
+    let cb_interval = Duration::from_millis(50);
+    let (counter, timer) = create_counter_and_timer(cb_interval);
+
+    Timer::<MockEvent, MockLogTemplate>::start(&timer);
+    // wait some deltas to let the timer thread start and increment the counter
+    ::std::thread::sleep(cb_interval * 2);
+
+    // wait some deltas to make sure timer thread stopped
+    Timer::<MockEvent, MockLogTemplate>::stop(&timer);
+
+    let counter_value_after_stop = *counter.lock().unwrap();
+    // wait some deltas to make sure timer thread stopped
+    ::std::thread::sleep(cb_interval * 2);
+
+    assert_eq!(counter_value_after_stop, *counter.lock().unwrap());
+}
+
+#[test]
+fn test_freshly_created_timer_is_stopped_on_drop() {
+    let cb_interval = Duration::from_millis(50);
+    let _ = create_counter_and_timer(cb_interval);
+}
+
+#[test]
+fn test_started_timer_is_stopped_on_drop() {
+    let cb_interval = Duration::from_millis(50);
+    let (_, timer) = create_counter_and_timer(cb_interval);
+
+    Timer::<MockEvent, MockLogTemplate>::start(&timer);
+}
+
+#[test]
+fn test_stopped_timer_is_stopped_on_drop() {
+    let cb_interval = Duration::from_millis(50);
+    let (_, timer) = create_counter_and_timer(cb_interval);
+
+    Timer::<MockEvent, MockLogTemplate>::start(&timer);
+    Timer::<MockEvent, MockLogTemplate>::stop(&timer);
+}

--- a/python-parser/Cargo.toml
+++ b/python-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "python-parser"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Tibor Benke <ihrwein@gmail.com>"]
 build = "build.rs"
 

--- a/python-parser/src/lib.rs
+++ b/python-parser/src/lib.rs
@@ -144,6 +144,17 @@ fn python_debug_callback(_: Python, debug_message: &str) -> PyResult<NoArgs> {
     Ok(NoArgs)
 }
 
+impl<P: Pipe> Clone for PythonParserBuilder<P> {
+    fn clone(&self) -> Self {
+        PythonParserBuilder {
+            module: self.module.clone(),
+            class: self.class.clone(),
+            options: self.options.clone(),
+            _marker: PhantomData
+        }
+    }
+}
+
 impl<P: Pipe> ParserBuilder<P> for PythonParserBuilder<P> {
     type Parser = PythonParser<P>;
     fn new(_: GlobalConfig) -> Self {

--- a/python-parser/src/lib.rs
+++ b/python-parser/src/lib.rs
@@ -12,7 +12,7 @@ use std::borrow::Borrow;
 use std::marker::PhantomData;
 
 use syslog_ng_common::{LogMessage, Parser, ParserBuilder, OptionError, Pipe, GlobalConfig};
-use cpython::{Python, PyDict, NoArgs, PyClone, PyObject, PyResult, PyModule, PyErr, PyString, ToPyObject};
+use cpython::{Python, PyDict, NoArgs, PyObject, PyResult, PyModule, PyErr, PyString, ToPyObject};
 use cpython::ObjectProtocol; //for call method
 use cpython::exc::TypeError;
 
@@ -26,14 +26,6 @@ pub mod options {
 pub struct PythonParser<P: Pipe> {
     parser: PyObject,
     _marker: PhantomData<P>
-}
-
-impl<P: Pipe> Clone for PythonParser<P> {
-    fn clone(&self) -> Self {
-        let gil = Python::acquire_gil();
-        let py = gil.python(); // obtain `Python` token
-        PythonParser {parser: self.parser.clone_ref(py), _marker: PhantomData}
-    }
 }
 
 pub struct PythonParserBuilder<P: Pipe> {

--- a/regex-parser/Cargo.toml
+++ b/regex-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regex-parser"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Tibor Benke <ihrwein@gmail.com>"]
 build = "build.rs"
 

--- a/regex-parser/src/lib.rs
+++ b/regex-parser/src/lib.rs
@@ -15,7 +15,6 @@ pub const REGEX_OPTION: &'static str = "regex";
 #[cfg(test)]
 mod tests;
 
-#[derive(Clone)]
 pub struct RegexParser {
     pub regex: Regex,
 }
@@ -23,6 +22,15 @@ pub struct RegexParser {
 pub struct RegexParserBuilder<P: Pipe> {
     regex: Option<Regex>,
     _marker: PhantomData<P>
+}
+
+impl<P> Clone for RegexParserBuilder<P> where P: Pipe {
+    fn clone(&self) -> Self {
+        RegexParserBuilder {
+            regex: self.regex.clone(),
+            _marker: PhantomData
+        }
+    }
 }
 
 impl<P: Pipe> ParserBuilder<P> for RegexParserBuilder<P> {

--- a/syslog-ng-rs/syslog-ng-common/Cargo.toml
+++ b/syslog-ng-rs/syslog-ng-common/Cargo.toml
@@ -17,3 +17,6 @@ glib-sys = "0.3.0"
 [[test]]
 name = "template_functions"
 harness = false
+
+[[test]]
+name = "dummy-parser"

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
@@ -57,6 +57,13 @@ pub mod _parser_plugin {
         let result = this.init();
         bool_to_int(result)
     }
+
+    #[no_mangle]
+    pub extern fn native_parser_proxy_deinit(this: &mut ParserProxy<$name>) -> c_int {
+        let result = this.deinit();
+        bool_to_int(result)
+    }
+
     #[no_mangle]
     pub extern fn native_parser_proxy_free(_: Box<ParserProxy<$name>>) {
     }

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
@@ -24,6 +24,8 @@ pub trait ParserBuilder<P: Pipe>: Clone {
 }
 
 pub trait Parser<P: Pipe> {
+    fn init(&mut self) -> bool { true }
+    fn deinit(&mut self) -> bool { true }
     fn parse(&mut self, pipe: &mut P, msg: &mut LogMessage, input: &str) -> bool;
 }
 

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
@@ -43,16 +43,18 @@ pub mod _parser_plugin {
 
     use super::*;
 
-    #[no_mangle]
-    pub extern fn native_parser_proxy_init(this: &mut ParserProxy<$name>) -> c_int {
-        let res = this.init();
-
-        match res {
+    fn bool_to_int(result: bool) -> c_int {
+        match result {
             true => 1,
             false => 0
         }
     }
 
+    #[no_mangle]
+    pub extern fn native_parser_proxy_init(this: &mut ParserProxy<$name>) -> c_int {
+        let result = this.init();
+        bool_to_int(result)
+    }
     #[no_mangle]
     pub extern fn native_parser_proxy_free(_: Box<ParserProxy<$name>>) {
     }

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
@@ -16,14 +16,14 @@ pub use self::option_error::OptionError;
 pub use self::proxy::ParserProxy;
 use GlobalConfig;
 
-pub trait ParserBuilder<P: Pipe> {
+pub trait ParserBuilder<P: Pipe>: Clone {
     type Parser: Parser<P>;
     fn new(GlobalConfig) -> Self;
     fn option(&mut self, _name: String, _value: String) {}
     fn build(self) -> Result<Self::Parser, OptionError>;
 }
 
-pub trait Parser<P: Pipe>: Clone {
+pub trait Parser<P: Pipe> {
     fn parse(&mut self, pipe: &mut P, msg: &mut LogMessage, input: &str) -> bool;
 }
 

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
@@ -29,12 +29,12 @@ impl<B> ParserProxy<B> where B: ParserBuilder<LogParser>
         }
     }
 
-    pub fn init(&mut self) -> bool {
-        let builder = self.builder.take().expect("Called init when builder was not set");
+    fn build_parser(&mut self, builder: B) -> bool {
         match builder.build() {
-            Ok(parser) => {
+            Ok(mut parser) => {
+                let init_result = parser.init();
                 self.parser = Some(parser);
-                true
+                init_result
             }
             Err(error) => {
                 error!("Error: {:?}", error);
@@ -43,6 +43,17 @@ impl<B> ParserProxy<B> where B: ParserBuilder<LogParser>
         }
     }
 
+    pub fn init(&mut self) -> bool {
+        if let Some(builder) = self.builder.take()  {
+            return self.build_parser(builder);
+        }
+
+        if let Some(ref mut parser) = self.parser {
+            parser.init()
+        } else {
+            false
+        }
+    }
 
     pub fn deinit(&mut self) -> bool {
         if let Some(ref mut parser) = self.parser {

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
@@ -58,7 +58,6 @@ impl<B> ParserProxy<B> where B: ParserBuilder<LogParser>
 
 impl<B> Clone for ParserProxy<B> where B: ParserBuilder<LogParser> {
     fn clone(&self) -> ParserProxy<B> {
-        // it makes no sense to clone() the builder
-        ParserProxy {parser: self.parser.clone(), builder: None}
+        ParserProxy {parser: None, builder: self.builder.clone()}
     }
 }

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
@@ -16,8 +16,8 @@ pub use proxies::parser::{OptionError, Parser, ParserBuilder};
 pub struct ParserProxy<B>
     where B: ParserBuilder<LogParser>
 {
-    pub parser: Option<B::Parser>,
-    pub builder: Option<B>,
+    parser: Option<B::Parser>,
+    builder: Option<B>,
 }
 
 impl<B> ParserProxy<B> where B: ParserBuilder<LogParser>

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
@@ -43,6 +43,15 @@ impl<B> ParserProxy<B> where B: ParserBuilder<LogParser>
         }
     }
 
+
+    pub fn deinit(&mut self) -> bool {
+        if let Some(ref mut parser) = self.parser {
+            parser.deinit()
+        } else {
+            false
+        }
+    }
+
     pub fn set_option(&mut self, name: String, value: String) {
         let builder = self.builder.as_mut().expect("Failed to get builder on a ParserProxy");
         builder.option(name, value);

--- a/syslog-ng-rs/syslog-ng-common/tests/dummy-parser.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/dummy-parser.rs
@@ -48,6 +48,12 @@ impl<P: Pipe> Parser<P> for DummyParser<P> {
     }
 }
 
+impl<P: Pipe> Clone for DummyParserBuilder<P> {
+    fn clone(&self) -> Self {
+        DummyParserBuilder(PhantomData)
+    }
+}
+
 // this verifies that the macro can be expanded
 parser_plugin!(DummyParserBuilder<LogParser>);
 

--- a/syslog-ng-rs/syslog-ng-common/tests/dummy-parser.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/dummy-parser.rs
@@ -43,7 +43,7 @@ impl<P: Pipe> ParserBuilder<P> for DummyParserBuilder<P> {
 impl<P: Pipe> Parser<P> for DummyParser<P> {
     fn parse(&mut self, _: &mut P, message: &mut LogMessage, input: &str) -> bool {
         debug!("Processing input in Rust Parser: {}", input);
-        message.insert("input", input);
+        message.insert(&b"input"[..], input.as_bytes());
         true
     }
 }
@@ -73,5 +73,6 @@ fn test_given_parser_implementation_when_it_receives_a_message_then_it_adds_a_sp
     let mut pipe = DummyPipe;
     let result = parser.parse(&mut pipe, &mut msg, input);
     assert!(result);
-    assert_eq!(msg.get("input").unwrap(), input);
+    assert_eq!(msg.get(&b"input"[..]).unwrap(), input.as_bytes());
 }
+

--- a/syslog-ng-rs/syslog-ng-common/tests/dummy-parser.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/dummy-parser.rs
@@ -51,7 +51,7 @@ impl<P: Pipe> Clone for DummyParserBuilder<P> {
 // this verifies that the macro can be expanded
 parser_plugin!(DummyParserBuilder<LogParser>);
 
-use syslog_ng_common::{SYSLOG_NG_INITIALIZED, syslog_ng_global_init};
+use syslog_ng_common::{SYSLOG_NG_INITIALIZED, syslog_ng_global_init, ParserProxy, LogParser};
 
 struct DummyPipe;
 
@@ -76,3 +76,16 @@ fn test_given_parser_implementation_when_it_receives_a_message_then_it_adds_a_sp
     assert_eq!(msg.get(&b"input"[..]).unwrap(), input.as_bytes());
 }
 
+#[test]
+fn test_parser_proxy_can_be_deinitialized() {
+    SYSLOG_NG_INITIALIZED.call_once(|| {
+        unsafe { syslog_ng_global_init(); }
+    });
+    let cfg = GlobalConfig::new(0x0308);
+    let mut proxy = ParserProxy::<DummyParserBuilder<LogParser>>::new(cfg);
+    proxy.set_option("foo".to_owned(), "bar".to_owned());
+    proxy.init();
+    proxy.deinit();
+    proxy.init();
+    proxy.deinit();
+}

--- a/syslog-ng-rs/syslog-ng-common/tests/dummy-parser.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/dummy-parser.rs
@@ -15,12 +15,6 @@ use std::marker::PhantomData;
 
 pub struct DummyParser<P: Pipe>(PhantomData<P>);
 
-impl<P: Pipe> Clone for DummyParser<P> {
-    fn clone(&self) -> DummyParser<P> {
-        DummyParser(self.0.clone())
-    }
-}
-
 pub struct DummyParserBuilder<P: Pipe>(PhantomData<P>);
 
 use syslog_ng_common::LogMessage;


### PR DESCRIPTION
This PR is the sibling of https://github.com/balabit/syslog-ng/pull/1103.

Contents:
* we had a dummy-parser, but we accidentally removed it's building. This PR fixes this.
* some code are extracted into functions
* `Parser` trait no longer requires the implementation of the `Clone` trait (and the implementation are removed from all parsers)
* `ParserBuilder` trait requires the implementation of `Clone` (the implementation is added for all parsers)
* add `init()` and `deinit()` methods to `Parser`
* forward `deinit()` calls through `ParserProxy` to `Parser`
* implement `init()` in `CorrelationParserBuilder`
  * we need to start and stop timers here, so I added those methods with tests here
* implement `Clone` for `CorrelationParserBuilder`
  * I had to wrap some types into `Arc`, because we will clone them (http://doc.rust-lang.org/std/sync/struct.Arc.html)
  * I renamed a field, because it's name was misleading.
* I also found a bug (`prefix()` doesn't work), I reported the error but haven't fixed it yet.
* version bumps for all parsers (It's useful to see from the build logs, what version we built from each parser...)