### PR TITLE
Fix empty string match

### DIFF
--- a/actiondb-parser/actiondb/src/matcher/suffix_array/impls.rs
+++ b/actiondb-parser/actiondb/src/matcher/suffix_array/impls.rs
@@ -249,7 +249,7 @@ impl Matcher for SuffixTable {
     fn parse<'a, 'b>(&'a self, value: &'b str) -> Option<MatchResult<'a, 'b>> {
         if let Some(child) = self.longest_common_prefix(value) {
             let common_prefix_len = child.literal().common_prefix_len(value);
-            if common_prefix_len == value.len() {
+            if common_prefix_len == value.len() && common_prefix_len == child.literal().len() {
                 child.pattern().and_then(|pattern| Some(MatchResult::new(pattern)))
             } else if common_prefix_len < value.len() {
                 let value = value.ltrunc(common_prefix_len);

--- a/actiondb-parser/actiondb/src/matcher/suffix_array/impls.rs
+++ b/actiondb-parser/actiondb/src/matcher/suffix_array/impls.rs
@@ -203,6 +203,12 @@ impl ParserEntry for ParserE {
     }
 }
 
+pub enum MatchType {
+    Exact,
+    Partial(usize),
+    None
+}
+
 #[derive(Debug, Clone)]
 pub struct LiteralE {
     pattern: Option<Pattern>,
@@ -216,6 +222,18 @@ impl LiteralE {
             literal: literal,
             pattern: None,
             child: None
+        }
+    }
+
+    pub fn determine_match_type(&self, value: &str) -> MatchType {
+        let common_prefix_len = self.literal().common_prefix_len(value);
+
+        if common_prefix_len == value.len() && common_prefix_len == self.literal().len() {
+            MatchType::Exact
+        } else if common_prefix_len < value.len() {
+            MatchType::Partial(common_prefix_len)
+        } else {
+            MatchType::None
         }
     }
 }
@@ -248,14 +266,15 @@ impl LiteralEntry for LiteralE {
 impl Matcher for SuffixTable {
     fn parse<'a, 'b>(&'a self, value: &'b str) -> Option<MatchResult<'a, 'b>> {
         if let Some(child) = self.longest_common_prefix(value) {
-            let common_prefix_len = child.literal().common_prefix_len(value);
-            if common_prefix_len == value.len() && common_prefix_len == child.literal().len() {
-                child.pattern().and_then(|pattern| Some(MatchResult::new(pattern)))
-            } else if common_prefix_len < value.len() {
-                let value = value.ltrunc(common_prefix_len);
-                child.child().and_then(|child| child.parse(value))
-            } else {
-                None
+            match child.determine_match_type(value) {
+                MatchType::Exact => {
+                    child.pattern().and_then(|pattern| Some(MatchResult::new(pattern)))
+                },
+                MatchType::Partial(common_prefix_len) => {
+                    let value = value.ltrunc(common_prefix_len);
+                    child.child().and_then(|child| child.parse(value))
+                },
+                MatchType::None => None
             }
         } else {
             self.parse_with_parsers(value)

--- a/actiondb-parser/actiondb/src/matcher/suffix_array/test.rs
+++ b/actiondb-parser/actiondb/src/matcher/suffix_array/test.rs
@@ -161,3 +161,17 @@ fn test_given_parser_when_it_receives_utf_8_strings_then_it_does_not_panic() {
 
     assert_eq!(true, root.parse("micek ¡micek").is_some());
 }
+
+#[test]
+fn test_given_parser_when_it_receives_empty_message_and_there_is_no_matching_pattern_then_we_do_not_return_a_match() {
+    let pattern = "aaa";
+    let compiled_pattern = ::grammar::parser::pattern(pattern).unwrap();
+
+    let mut pattern = Pattern::with_random_uuid();
+    pattern.set_pattern(compiled_pattern);
+
+    let mut root = SuffixTable::new();
+    root.insert(pattern);
+
+    assert_eq!(true, root.parse("").is_none());
+}


### PR DESCRIPTION
Root cause: we ignored the fact, that there could be some remaining
characters in the pattern.

Solution: make sure, that we found an exact match