### PR TITLE
Catch panics on Rust - C FFI boundary

### DIFF
--- a/syslog-ng-rs/syslog-ng-common/Cargo.toml
+++ b/syslog-ng-rs/syslog-ng-common/Cargo.toml
@@ -21,3 +21,6 @@ harness = false
 
 [[test]]
 name = "dummy-parser"
+
+[[test]]
+name = "panicking-parser"

--- a/syslog-ng-rs/syslog-ng-common/Cargo.toml
+++ b/syslog-ng-rs/syslog-ng-common/Cargo.toml
@@ -13,6 +13,7 @@ log = "0.3"
 syslog-ng-sys = "0.3"
 glib = "0.0.8"
 glib-sys = "0.3.0"
+libc = "0.2.13"
 
 [[test]]
 name = "template_functions"

--- a/syslog-ng-rs/syslog-ng-common/src/lib.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/lib.rs
@@ -38,7 +38,7 @@ pub use logmsg::LogMessage;
 pub use formatter::MessageFormatter;
 pub use logger::init_logger;
 pub use cfg::GlobalConfig;
-pub use proxies::parser::{OptionError, Parser, ParserBuilder, ParserProxy};
+pub use proxies::parser::{OptionError, Parser, ParserBuilder, ParserProxy, abort_on_panic, bool_to_int};
 pub use logpipe::{LogPipe, Pipe};
 pub use logtemplate::{LogTemplate, LogTemplateOptions, LogTimeZone};
 pub use plugin::Plugin;

--- a/syslog-ng-rs/syslog-ng-common/src/lib.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/lib.rs
@@ -16,6 +16,7 @@ extern crate glib_sys;
 extern crate libc;
 
 use std::sync::{Once, ONCE_INIT};
+use libc::abort;
 
 #[macro_use]
 mod proxies;
@@ -52,4 +53,10 @@ pub unsafe fn syslog_ng_global_init() {
     sys::logmsg::log_msg_registry_init();
     sys::logmsg::log_tags_global_init();
     sys::logtemplate::log_template_global_init();
+}
+
+pub fn commit_suicide() -> ! {
+    unsafe {
+        abort();
+    };
 }

--- a/syslog-ng-rs/syslog-ng-common/src/lib.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/lib.rs
@@ -13,6 +13,7 @@ extern crate log;
 extern crate syslog_ng_sys;
 extern crate glib;
 extern crate glib_sys;
+extern crate libc;
 
 use std::sync::{Once, ONCE_INIT};
 

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
@@ -73,8 +73,19 @@ pub mod _parser_plugin {
 
     #[no_mangle]
     pub extern fn native_parser_proxy_deinit(this: &mut ParserProxy<$name>) -> c_int {
-        let result = this.deinit();
-        bool_to_int(result)
+        let mut wrapper = AssertUnwindSafe(this);
+
+        let unwind_safe_call = move || {
+            bool_to_int(wrapper.deinit())
+        };
+
+        match catch_unwind(unwind_safe_call) {
+            Ok(deinit_result) => deinit_result,
+            Err(error) => {
+                error!("native_parser_proxy_deinit() panicked, but the panic was cought: {:?}", error);
+                commit_suicide();
+            }
+        }
     }
 
     #[no_mangle]

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
@@ -184,8 +184,13 @@ pub mod _parser_plugin {
     pub extern fn native_parser_proxy_clone(this: &ParserProxy<$name>) -> *mut ParserProxy<$name> {
         let wrapper_this = AssertUnwindSafe(this);
 
-        match catch_unwind(move || (*wrapper_this).clone()) {
-            Ok(cloned) => Box::into_raw(Box::new(cloned)),
+        let unwind_safe_call = move || {
+            let cloned = (*wrapper_this).clone();
+            Box::into_raw(Box::new(cloned))
+        };
+
+        match catch_unwind(unwind_safe_call) {
+            Ok(cloned) => cloned,
             Err(error) => {
                 error!("native_parser_proxy_clone() panicked, but the panic was caught: {:?}", error);
                 commit_suicide();

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
@@ -65,7 +65,7 @@ pub mod _parser_plugin {
         match catch_unwind(unwind_safe_call) {
             Ok(init_result) => init_result,
             Err(error) => {
-                error!("native_parser_proxy_init() panicked, but the panic was cought: {:?}", error);
+                error!("native_parser_proxy_init() panicked, but the panic was caught: {:?}", error);
                 commit_suicide();
             }
         }
@@ -82,7 +82,7 @@ pub mod _parser_plugin {
         match catch_unwind(unwind_safe_call) {
             Ok(deinit_result) => deinit_result,
             Err(error) => {
-                error!("native_parser_proxy_deinit() panicked, but the panic was cought: {:?}", error);
+                error!("native_parser_proxy_deinit() panicked, but the panic was caught: {:?}", error);
                 commit_suicide();
             }
         }
@@ -99,7 +99,7 @@ pub mod _parser_plugin {
         match catch_unwind(unwind_safe_call) {
             Ok(()) => (),
             Err(error) => {
-                error!("native_parser_proxy_free() panicked, but the panic was cought: {:?}", error);
+                error!("native_parser_proxy_free() panicked, but the panic was caught: {:?}", error);
                 commit_suicide();
             },
         }
@@ -121,7 +121,7 @@ pub mod _parser_plugin {
         match result {
             Ok(()) => (),
             Err(error) => {
-                error!("native_parser_proxy_set_option() panicked, but the panic was cought: {:?}", error);
+                error!("native_parser_proxy_set_option() panicked, but the panic was caught: {:?}", error);
                 commit_suicide();
             }
         }
@@ -156,7 +156,7 @@ pub mod _parser_plugin {
         match result {
             Ok(process_result) => process_result,
             Err(error) => {
-                error!("native_parser_proxy_process() panicked, but the panic was cought: {:?}", error);
+                error!("native_parser_proxy_process() panicked, but the panic was caught: {:?}", error);
                 commit_suicide();
             }
         }
@@ -174,7 +174,7 @@ pub mod _parser_plugin {
         match result {
             Ok(proxy) => proxy,
             Err(error) => {
-                error!("native_parser_proxy_new() panicked, but the panic was cought: {:?}", error);
+                error!("native_parser_proxy_new() panicked, but the panic was caught: {:?}", error);
                 commit_suicide();
             }
         }

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
@@ -29,7 +29,7 @@ impl<B> ParserProxy<B> where B: ParserBuilder<LogParser>
         }
     }
 
-    pub fn with_parser_and_builder(builder: Option<B>,
+    pub fn with_builder_and_parser(builder: Option<B>,
                                    parser: Option<B::Parser>)
                                    -> ParserProxy<B> {
         ParserProxy {

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
@@ -29,6 +29,15 @@ impl<B> ParserProxy<B> where B: ParserBuilder<LogParser>
         }
     }
 
+    pub fn with_parser_and_builder(builder: Option<B>,
+                                   parser: Option<B::Parser>)
+                                   -> ParserProxy<B> {
+        ParserProxy {
+            parser: parser,
+            builder: builder,
+        }
+    }
+
     fn build_parser(&mut self, builder: B) -> bool {
         match builder.build() {
             Ok(mut parser) => {

--- a/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
@@ -126,7 +126,6 @@ fn test_native_parser_proxy_free_wont_panic_even_if_the_proxy_panics() {
     assert_child_commits_suicide(|| {
         set_up_test();
 
-
         let proxy = ParserProxy::with_builder_and_parser(None, Some(PanickingParser(PhantomData)));
         let _ = native_parser_proxy_free(Box::into_raw(Box::new(proxy)));
     });
@@ -138,7 +137,7 @@ fn test_native_parser_proxy_set_option_wont_panic_even_if_the_proxy_panics() {
         set_up_test();
 
         let mut proxy =
-            ParserProxy::with_parser_and_builder(Some(PanickingParserBuilder(PhantomData)), None);
+            ParserProxy::with_builder_and_parser(Some(PanickingParserBuilder(PhantomData)), None);
         let key = CString::new("key").unwrap();
         let value = CString::new("value").unwrap();
         let _ = native_parser_proxy_set_option(&mut proxy, key.as_ptr(), value.as_ptr());
@@ -151,7 +150,7 @@ fn test_native_parser_proxy_init_wont_panic_even_if_the_proxy_panics() {
         set_up_test();
 
         let mut proxy =
-            ParserProxy::with_parser_and_builder(Some(PanickingParserBuilder(PhantomData)), None);
+            ParserProxy::with_builder_and_parser(Some(PanickingParserBuilder(PhantomData)), None);
         let _ = native_parser_proxy_init(&mut proxy);
     });
 }
@@ -161,7 +160,7 @@ fn test_native_parser_proxy_deinit_wont_panic_even_if_the_proxy_panics() {
     assert_child_commits_suicide(|| {
         set_up_test();
 
-        let mut proxy = ParserProxy::with_parser_and_builder(None,
+        let mut proxy = ParserProxy::with_builder_and_parser(None,
                                                              Some(PanickingParser(PhantomData)));
         let _ = native_parser_proxy_deinit(&mut proxy);
     });
@@ -172,7 +171,7 @@ fn test_native_parser_proxy_process_wont_panic_even_if_the_proxy_panics() {
     assert_child_commits_suicide(|| {
         set_up_test();
 
-        let mut proxy = ParserProxy::with_parser_and_builder(None,
+        let mut proxy = ParserProxy::with_builder_and_parser(None,
                                                              Some(PanickingParser(PhantomData)));
         let parser: *mut sys::LogParser = ::std::ptr::null_mut();
         let input = CString::new("input").unwrap();
@@ -186,7 +185,7 @@ fn test_native_parser_proxy_clone_wont_panic_even_if_the_proxy_panics() {
     assert_child_commits_suicide(|| {
         set_up_test();
 
-        let proxy = ParserProxy::with_parser_and_builder(Some(PanickingParserBuilder(PhantomData)),
+        let proxy = ParserProxy::with_builder_and_parser(Some(PanickingParserBuilder(PhantomData)),
                                                          None);
         let _ = native_parser_proxy_clone(&proxy);
     });

--- a/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
@@ -63,6 +63,9 @@ impl<P: Pipe> Clone for PanickingParserBuilder<P> {
 // this verifies that the macro can be expanded
 parser_plugin!(PanickingParserBuilder<LogParser>);
 
+use _parser_plugin::native_parser_proxy_new;
+
+
 fn set_up_test() {
     SYSLOG_NG_INITIALIZED.call_once(|| {
         unsafe {
@@ -103,4 +106,14 @@ fn assert_child_commits_suicide<C>(child_callback: C)
     };
 
     fork_with_callbacks(child_callback, parent_callback).unwrap();
+}
+
+#[test]
+fn test_native_parser_proxy_new_wont_panic_even_if_the_proxy_panics() {
+    assert_child_commits_suicide(|| {
+        set_up_test();
+
+        let cfg = GlobalConfig::new(0x0308);
+        let _ = native_parser_proxy_new(cfg.raw_ptr());
+    });
 }

--- a/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
@@ -65,7 +65,8 @@ parser_plugin!(PanickingParserBuilder<LogParser>);
 
 use _parser_plugin::{native_parser_proxy_new, native_parser_proxy_free,
                      native_parser_proxy_set_option, native_parser_proxy_init,
-                     native_parser_proxy_deinit, native_parser_proxy_process};
+                     native_parser_proxy_deinit, native_parser_proxy_process,
+                     native_parser_proxy_clone};
 
 
 fn set_up_test() {
@@ -177,5 +178,16 @@ fn test_native_parser_proxy_process_wont_panic_even_if_the_proxy_panics() {
         let input = CString::new("input").unwrap();
         let msg = LogMessage::new();
         let _ = native_parser_proxy_process(&mut proxy, parser, msg.0, input.as_ptr());
+    });
+}
+
+#[test]
+fn test_native_parser_proxy_clone_wont_panic_even_if_the_proxy_panics() {
+    assert_child_commits_suicide(|| {
+        set_up_test();
+
+        let proxy = ParserProxy::with_parser_and_builder(Some(PanickingParserBuilder(PhantomData)),
+                                                         None);
+        let _ = native_parser_proxy_clone(&proxy);
     });
 }

--- a/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
@@ -1,0 +1,61 @@
+// Copyright (c) 2016 Tibor Benke <ihrwein@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+#[macro_use]
+extern crate syslog_ng_common;
+#[macro_use]
+extern crate log;
+extern crate libc;
+
+use std::marker::PhantomData;
+
+use syslog_ng_common::{SYSLOG_NG_INITIALIZED, syslog_ng_global_init, ParserProxy, LogMessage,
+                       Parser, ParserBuilder, OptionError, Pipe, GlobalConfig};
+use syslog_ng_common::sys;
+
+pub struct PanickingParser<P: Pipe>(PhantomData<P>);
+
+pub struct PanickingParserBuilder<P: Pipe>(PhantomData<P>);
+
+impl<P: Pipe> Drop for PanickingParser<P> {
+    fn drop(&mut self) {
+        panic!("panic! in Drop");
+    }
+}
+
+impl<P: Pipe> ParserBuilder<P> for PanickingParserBuilder<P> {
+    type Parser = PanickingParser<P>;
+    fn new(_: GlobalConfig) -> Self {
+        panic!("new() panicked");
+    }
+    fn option(&mut self, _: String, _: String) {
+        panic!("option() panicked");
+    }
+    fn build(self) -> Result<Self::Parser, OptionError> {
+        panic!("build() panicked");
+    }
+}
+
+impl<P: Pipe> Parser<P> for PanickingParser<P> {
+    fn parse(&mut self, _: &mut P, _: &mut LogMessage, _: &str) -> bool {
+        panic!("parse() panicked");
+    }
+
+    fn deinit(&mut self) -> bool {
+        panic!("deinit() panicked");
+    }
+}
+
+impl<P: Pipe> Clone for PanickingParserBuilder<P> {
+    fn clone(&self) -> Self {
+        panic!("clone() panicked")
+    }
+}
+
+// this verifies that the macro can be expanded
+parser_plugin!(PanickingParserBuilder<LogParser>);

--- a/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
@@ -64,7 +64,7 @@ impl<P: Pipe> Clone for PanickingParserBuilder<P> {
 parser_plugin!(PanickingParserBuilder<LogParser>);
 
 use _parser_plugin::{native_parser_proxy_new, native_parser_proxy_free,
-                     native_parser_proxy_set_option};
+                     native_parser_proxy_set_option, native_parser_proxy_init};
 
 
 fn set_up_test() {
@@ -140,5 +140,16 @@ fn test_native_parser_proxy_set_option_wont_panic_even_if_the_proxy_panics() {
         let key = CString::new("key").unwrap();
         let value = CString::new("value").unwrap();
         let _ = native_parser_proxy_set_option(&mut proxy, key.as_ptr(), value.as_ptr());
+    });
+}
+
+#[test]
+fn test_native_parser_proxy_init_wont_panic_even_if_the_proxy_panics() {
+    assert_child_commits_suicide(|| {
+        set_up_test();
+
+        let mut proxy =
+            ParserProxy::with_parser_and_builder(Some(PanickingParserBuilder(PhantomData)), None);
+        let _ = native_parser_proxy_init(&mut proxy);
     });
 }

--- a/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
@@ -63,7 +63,8 @@ impl<P: Pipe> Clone for PanickingParserBuilder<P> {
 // this verifies that the macro can be expanded
 parser_plugin!(PanickingParserBuilder<LogParser>);
 
-use _parser_plugin::{native_parser_proxy_new, native_parser_proxy_free};
+use _parser_plugin::{native_parser_proxy_new, native_parser_proxy_free,
+                     native_parser_proxy_set_option};
 
 
 fn set_up_test() {
@@ -126,5 +127,18 @@ fn test_native_parser_proxy_free_wont_panic_even_if_the_proxy_panics() {
 
         let proxy = ParserProxy::with_builder_and_parser(None, Some(PanickingParser(PhantomData)));
         let _ = native_parser_proxy_free(Box::into_raw(Box::new(proxy)));
+    });
+}
+
+#[test]
+fn test_native_parser_proxy_set_option_wont_panic_even_if_the_proxy_panics() {
+    assert_child_commits_suicide(|| {
+        set_up_test();
+
+        let mut proxy =
+            ParserProxy::with_parser_and_builder(Some(PanickingParserBuilder(PhantomData)), None);
+        let key = CString::new("key").unwrap();
+        let value = CString::new("value").unwrap();
+        let _ = native_parser_proxy_set_option(&mut proxy, key.as_ptr(), value.as_ptr());
     });
 }

--- a/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
@@ -13,6 +13,9 @@ extern crate log;
 extern crate libc;
 
 use std::marker::PhantomData;
+use std::ffi::CString;
+
+use libc::{SIGABRT, waitpid, fork, WIFSIGNALED, WTERMSIG, pid_t};
 
 use syslog_ng_common::{SYSLOG_NG_INITIALIZED, syslog_ng_global_init, ParserProxy, LogMessage,
                        Parser, ParserBuilder, OptionError, Pipe, GlobalConfig};
@@ -59,3 +62,45 @@ impl<P: Pipe> Clone for PanickingParserBuilder<P> {
 
 // this verifies that the macro can be expanded
 parser_plugin!(PanickingParserBuilder<LogParser>);
+
+fn set_up_test() {
+    SYSLOG_NG_INITIALIZED.call_once(|| {
+        unsafe {
+            syslog_ng_global_init();
+        }
+    });
+}
+
+pub fn fork_with_callbacks<C, P>(child_callback: C, parent_callback: P) -> Result<(), ()>
+    where C: FnOnce(),
+          P: FnOnce(pid_t)
+{
+    match unsafe { fork() } {
+        0 => {
+            child_callback();
+            Ok(())
+        }
+        x if x > 0 => {
+            parent_callback(x);
+            Ok(())
+        }
+        -1 | _ => Err(()),
+    }
+}
+
+fn assert_child_commits_suicide<C>(child_callback: C)
+    where C: FnOnce()
+{
+    let parent_callback = |child_pid| {
+        let mut status = 0;
+        let options = 0;
+        unsafe {
+            let result = waitpid(child_pid, &mut status, options);
+            assert!(result != -1);
+            assert!(WIFSIGNALED(status));
+            assert_eq!(SIGABRT, WTERMSIG(status));
+        };
+    };
+
+    fork_with_callbacks(child_callback, parent_callback).unwrap();
+}

--- a/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
@@ -64,7 +64,8 @@ impl<P: Pipe> Clone for PanickingParserBuilder<P> {
 parser_plugin!(PanickingParserBuilder<LogParser>);
 
 use _parser_plugin::{native_parser_proxy_new, native_parser_proxy_free,
-                     native_parser_proxy_set_option, native_parser_proxy_init};
+                     native_parser_proxy_set_option, native_parser_proxy_init,
+                     native_parser_proxy_deinit};
 
 
 fn set_up_test() {
@@ -151,5 +152,16 @@ fn test_native_parser_proxy_init_wont_panic_even_if_the_proxy_panics() {
         let mut proxy =
             ParserProxy::with_parser_and_builder(Some(PanickingParserBuilder(PhantomData)), None);
         let _ = native_parser_proxy_init(&mut proxy);
+    });
+}
+
+#[test]
+fn test_native_parser_proxy_deinit_wont_panic_even_if_the_proxy_panics() {
+    assert_child_commits_suicide(|| {
+        set_up_test();
+
+        let mut proxy = ParserProxy::with_parser_and_builder(None,
+                                                             Some(PanickingParser(PhantomData)));
+        let _ = native_parser_proxy_deinit(&mut proxy);
     });
 }

--- a/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
@@ -65,7 +65,7 @@ parser_plugin!(PanickingParserBuilder<LogParser>);
 
 use _parser_plugin::{native_parser_proxy_new, native_parser_proxy_free,
                      native_parser_proxy_set_option, native_parser_proxy_init,
-                     native_parser_proxy_deinit};
+                     native_parser_proxy_deinit, native_parser_proxy_process};
 
 
 fn set_up_test() {
@@ -163,5 +163,19 @@ fn test_native_parser_proxy_deinit_wont_panic_even_if_the_proxy_panics() {
         let mut proxy = ParserProxy::with_parser_and_builder(None,
                                                              Some(PanickingParser(PhantomData)));
         let _ = native_parser_proxy_deinit(&mut proxy);
+    });
+}
+
+#[test]
+fn test_native_parser_proxy_process_wont_panic_even_if_the_proxy_panics() {
+    assert_child_commits_suicide(|| {
+        set_up_test();
+
+        let mut proxy = ParserProxy::with_parser_and_builder(None,
+                                                             Some(PanickingParser(PhantomData)));
+        let parser: *mut sys::LogParser = ::std::ptr::null_mut();
+        let input = CString::new("input").unwrap();
+        let msg = LogMessage::new();
+        let _ = native_parser_proxy_process(&mut proxy, parser, msg.0, input.as_ptr());
     });
 }

--- a/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/panicking-parser.rs
@@ -63,7 +63,7 @@ impl<P: Pipe> Clone for PanickingParserBuilder<P> {
 // this verifies that the macro can be expanded
 parser_plugin!(PanickingParserBuilder<LogParser>);
 
-use _parser_plugin::native_parser_proxy_new;
+use _parser_plugin::{native_parser_proxy_new, native_parser_proxy_free};
 
 
 fn set_up_test() {
@@ -115,5 +115,16 @@ fn test_native_parser_proxy_new_wont_panic_even_if_the_proxy_panics() {
 
         let cfg = GlobalConfig::new(0x0308);
         let _ = native_parser_proxy_new(cfg.raw_ptr());
+    });
+}
+
+#[test]
+fn test_native_parser_proxy_free_wont_panic_even_if_the_proxy_panics() {
+    assert_child_commits_suicide(|| {
+        set_up_test();
+
+
+        let proxy = ParserProxy::with_builder_and_parser(None, Some(PanickingParser(PhantomData)));
+        let _ = native_parser_proxy_free(Box::into_raw(Box::new(proxy)));
     });
 }


### PR DESCRIPTION
This PR makes the native_parser_proxy interface unwind safe. This means, that is case of panics the parsers are not left in invalid states.

The following actions were takes:
* panic!-s are caught on the Rust - C FFI boundary
* syslog-ng is abort()-ed

Some useful documentation on the subject (unwind safety):
* http://doc.rust-lang.org/std/panic/trait.UnwindSafe.html
* http://doc.rust-lang.org/std/panic/fn.catch_unwind.html
* http://doc.rust-lang.org/std/panic/struct.AssertUnwindSafe.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ihrwein/syslog-ng-rust-modules/30)
<!-- Reviewable:end -->
