### PR TITLE
Add unit test for spinning

### DIFF
--- a/correlation-parser/correlation/tests/correlator/mod.rs
+++ b/correlation-parser/correlation/tests/correlator/mod.rs
@@ -72,7 +72,7 @@ fn test_given_yaml_context_file_when_it_is_read_by_the_correlator_factory_then_t
 }
 
 #[test]
-fn test_name() {
+fn test_yaml_parser_reports_error_when_the_yaml_file_is_not_valid_yaml() {
     let _ = env_logger::init();
     let contexts_file = "tests/correlator/invalid.yaml";
     let result = CorrelatorFactory::load_file(contexts_file);

--- a/correlation-parser/tests/parse.rs
+++ b/correlation-parser/tests/parse.rs
@@ -45,3 +45,18 @@ fn test_alert_is_forwarded() {
     }
     assert_eq!(b"artificial test message", alert.get(&b"MESSAGE"[..]).unwrap());
 }
+
+#[test]
+fn test_syslog_ng_does_not_spin_with_invalid_yaml_configuration() {
+    let _ = env_logger::init();
+    SYSLOG_NG_INITIALIZED.call_once(|| {
+        unsafe { syslog_ng_global_init(); }
+    });
+
+    let config_file = "tests/spinning.json";
+
+    let cfg = GlobalConfig::new(0x0308);
+    let mut builder = CorrelationParserBuilder::<MockPipe, MockEvent, MockLogTemplate, MockLogTemplateFactory, MockTimer<MockEvent, MockLogTemplate>>::new(cfg);
+    builder.option(options::CONTEXTS_FILE.to_owned(), config_file.to_owned());
+    let _ = builder.build().err().unwrap();
+}

--- a/correlation-parser/tests/spinning.yml
+++ b/correlation-parser/tests/spinning.yml
@@ -1,0 +1,17 @@
+-
+  name: "GENERATED_LOGS"
+  uuid: "f7ee6a32-03a6-40d9-bd87-f48d1b4cd563"
+  patterns:
+    - "AAA"
+  conditions:
+    timeout: "0"
+  actions:
+    -
+      message:
+        uuid: "4bbd15c4-ec44-47a2-ada3-f7fe3ff81222"
+        inject_mode: "forward"
+        name: "GEN_LOGS"
+        message: "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+        values:
+           AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA: NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+          stamp: $(grep ("${.loggen.seq}" == "0000000003") ${.loggen.stamp})


### PR DESCRIPTION
Make sure syslog-ng doesn't spin.

This PR only adds a new unit test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ihrwein/syslog-ng-rust-modules/31)
<!-- Reviewable:end -->
