### PR TITLE
Remove debug_flag check from internal message sending

### DIFF
--- a/syslog-ng-rs/syslog-ng-common/Cargo.toml
+++ b/syslog-ng-rs/syslog-ng-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-ng-common"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Tibor Benke <ihrwein@gmail.com>"]
 homepage = "https://github.com/ihrwein/syslog-ng-rs"
 repository = "https://github.com/ihrwein/syslog-ng-rs"

--- a/syslog-ng-rs/syslog-ng-common/src/lib.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/lib.rs
@@ -57,6 +57,7 @@ pub unsafe fn syslog_ng_global_init() {
     sys::logmsg::log_msg_registry_init();
     sys::logmsg::log_tags_global_init();
     sys::logtemplate::log_template_global_init();
+    syslog_ng_sys::messages::msg_init(1 as c_int);
 }
 
 pub fn commit_suicide() -> ! {

--- a/syslog-ng-rs/syslog-ng-common/src/messages.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/messages.rs
@@ -37,12 +37,10 @@ pub struct InternalMessageSender;
 impl InternalMessageSender {
     pub fn create_and_send(severity: Msg, message: String) {
         unsafe {
-            if messages::debug_flag != 0 {
-                let msg = CString::new(message).unwrap();
-                let prio = severity as i32;
-                let msg_event = messages::msg_event_create_from_desc(prio, msg.as_ptr());
-                messages::msg_event_suppress_recursions_and_send(msg_event);
-            }
+            let msg = CString::new(message).unwrap();
+            let prio = severity as i32;
+            let msg_event = messages::msg_event_create_from_desc(prio, msg.as_ptr());
+            messages::msg_event_suppress_recursions_and_send(msg_event);
         };
     }
 

--- a/syslog-ng-rs/syslog-ng-sys/Cargo.toml
+++ b/syslog-ng-rs/syslog-ng-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-ng-sys"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Tibor Benke <ihrwein@gmail.com>"]
 build = "build.rs"
 links = "syslog-ng"

--- a/syslog-ng-rs/syslog-ng-sys/src/messages.rs
+++ b/syslog-ng-rs/syslog-ng-sys/src/messages.rs
@@ -14,6 +14,7 @@ pub enum EVTREC {}
 extern "C" {
     pub fn msg_event_create_from_desc(prio: i32, desc: *const c_char) -> *mut EVTREC;
     pub fn msg_event_suppress_recursions_and_send(e: *mut EVTREC);
+    pub fn msg_init(interactive: c_int);
     pub static debug_flag: c_int;
     pub static trace_flag: c_int;
 }


### PR DESCRIPTION
Before this change the error messages were omitted if the syslog-ng
was launched without the -d command-line switch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ihrwein/syslog-ng-rust-modules/39)
<!-- Reviewable:end -->
