### PR TITLE
Add docstrings and some small fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
 matrix:
   include:
     - env: RUST_CHANNEL=stable TEST_MODE=cmake
+  allow_failures:
+    - env: RUST_CHANNEL=nightly TEST_MODE=everything TRAVIS_CARGO_NIGHTLY_FEATURE=nightly
 
 git:
   submodules: false

--- a/actiondb-parser/Cargo.toml
+++ b/actiondb-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actiondb-parser"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Tibor Benke <tibor.benke@balabit.com>"]
 build = "build.rs"
 homepage = "https://github.com/ihrwein/actiondb-parser"

--- a/actiondb-parser/Cargo.toml
+++ b/actiondb-parser/Cargo.toml
@@ -24,4 +24,4 @@ syslog-ng-common = { path = "../syslog-ng-rs/syslog-ng-common" }
 clap = "2.3"
 
 [build-dependencies]
-syslog-ng-build = "0.2"
+syslog-ng-build = { path = "../syslog-ng-rs/syslog-ng-build" }

--- a/actiondb-parser/src/lib.rs
+++ b/actiondb-parser/src/lib.rs
@@ -44,7 +44,7 @@ impl<MS> ActiondbParserBuilder<MS> where MS: MatcherSuite, MS::Matcher: Clone {
     }
 }
 
-impl<MS, P> ParserBuilder<P> for ActiondbParserBuilder<MS> where P: Pipe, MS: MatcherSuite + Clone, MS::Matcher: Clone {
+impl<MS> ParserBuilder for ActiondbParserBuilder<MS> where MS: MatcherSuite + Clone, MS::Matcher: Clone {
     type Parser = ActiondbParser<MS::Matcher>;
     fn new(_: GlobalConfig) -> Self {
         ActiondbParserBuilder {
@@ -88,8 +88,8 @@ pub struct ActiondbParser<M> where M: Matcher + Clone {
     pub formatter: MessageFormatter,
 }
 
-impl<M, P> Parser<P> for ActiondbParser<M> where P: Pipe, M: Matcher + Clone {
-    fn parse(&mut self, _: &mut P, msg: &mut LogMessage, input: &str) -> bool {
+impl<M> Parser for ActiondbParser<M> where M: Matcher + Clone {
+    fn parse(&mut self, _: &mut Pipe, msg: &mut LogMessage, input: &str) -> bool {
         if let Some(result) = self.matcher.parse(input) {
             MessageFiller::fill_logmsg(&mut self.formatter, msg, &result);
             true

--- a/correlation-parser/Cargo.toml
+++ b/correlation-parser/Cargo.toml
@@ -16,4 +16,4 @@ syslog-ng-common = { path = "../syslog-ng-rs/syslog-ng-common" }
 path = "correlation"
 
 [build-dependencies]
-syslog-ng-build = "0.2.0"
+syslog-ng-build = { path = "../syslog-ng-rs/syslog-ng-build" }

--- a/correlation-parser/Cargo.toml
+++ b/correlation-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "correlation-parser"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Tibor Benke <ihrwein@gmail.com>"]
 build = "build.rs"
 

--- a/correlation-parser/src/mock.rs
+++ b/correlation-parser/src/mock.rs
@@ -1,5 +1,15 @@
 use syslog_ng_common::{LogMessage, GlobalConfig};
 use correlation::{Message, Event, EventIds, Template, TemplateFactory, CompileError};
+use TypeFamily;
+
+pub struct MockTypeFamily {}
+
+impl TypeFamily for MockTypeFamily {
+    type Event = MockEvent;
+    type Template = MockLogTemplate;
+    type TemplateFactory = MockLogTemplateFactory;
+    type Timer = MockTimer<MockEvent, MockLogTemplate>;
+}
 
 use std::io::Write;
 

--- a/correlation-parser/tests/parse.rs
+++ b/correlation-parser/tests/parse.rs
@@ -4,7 +4,7 @@ extern crate syslog_ng_common;
 extern crate env_logger;
 
 use correlation_parser::{CorrelationParserBuilder, options, CLASSIFIER_UUID, CLASSIFIER_CLASS};
-use correlation_parser::mock::{MockEvent, MockLogTemplate, MockLogTemplateFactory, MockTimer};
+use correlation_parser::mock::MockTypeFamily;
 use syslog_ng_common::{ParserBuilder, LogMessage, Parser, SYSLOG_NG_INITIALIZED, syslog_ng_global_init, GlobalConfig};
 use syslog_ng_common::mock::MockPipe;
 
@@ -25,7 +25,7 @@ fn test_alert_is_forwarded() {
 
     let mut pipe = MockPipe::new();
     let cfg = GlobalConfig::new(0x0308);
-    let mut builder = CorrelationParserBuilder::<MockEvent, MockLogTemplate, MockLogTemplateFactory, MockTimer<MockEvent, MockLogTemplate>>::new(cfg);
+    let mut builder = CorrelationParserBuilder::<MockTypeFamily>::new(cfg);
     builder.option(options::CONTEXTS_FILE.to_owned(), config_file.to_owned()).ok().unwrap();
     let mut parser = builder.build().unwrap();
     let timer = parser.timer.clone();
@@ -55,7 +55,7 @@ fn test_syslog_ng_does_not_spin_with_invalid_yaml_configuration() {
     let config_file = "tests/spinning.yml";
 
     let cfg = GlobalConfig::new(0x0308);
-    let mut builder = CorrelationParserBuilder::<MockEvent, MockLogTemplate, MockLogTemplateFactory, MockTimer<MockEvent, MockLogTemplate>>::new(cfg);
+    let mut builder = CorrelationParserBuilder::<MockTypeFamily>::new(cfg);
     builder.option(options::CONTEXTS_FILE.to_owned(), config_file.to_owned()).err().unwrap();
     let _ = builder.build().err().unwrap();
 }

--- a/correlation-parser/tests/parse.rs
+++ b/correlation-parser/tests/parse.rs
@@ -25,7 +25,7 @@ fn test_alert_is_forwarded() {
 
     let mut pipe = MockPipe::new();
     let cfg = GlobalConfig::new(0x0308);
-    let mut builder = CorrelationParserBuilder::<MockPipe, MockEvent, MockLogTemplate, MockLogTemplateFactory, MockTimer<MockEvent, MockLogTemplate>>::new(cfg);
+    let mut builder = CorrelationParserBuilder::<MockEvent, MockLogTemplate, MockLogTemplateFactory, MockTimer<MockEvent, MockLogTemplate>>::new(cfg);
     builder.option(options::CONTEXTS_FILE.to_owned(), config_file.to_owned()).ok().unwrap();
     let mut parser = builder.build().unwrap();
     let timer = parser.timer.clone();
@@ -55,7 +55,7 @@ fn test_syslog_ng_does_not_spin_with_invalid_yaml_configuration() {
     let config_file = "tests/spinning.yml";
 
     let cfg = GlobalConfig::new(0x0308);
-    let mut builder = CorrelationParserBuilder::<MockPipe, MockEvent, MockLogTemplate, MockLogTemplateFactory, MockTimer<MockEvent, MockLogTemplate>>::new(cfg);
+    let mut builder = CorrelationParserBuilder::<MockEvent, MockLogTemplate, MockLogTemplateFactory, MockTimer<MockEvent, MockLogTemplate>>::new(cfg);
     builder.option(options::CONTEXTS_FILE.to_owned(), config_file.to_owned()).err().unwrap();
     let _ = builder.build().err().unwrap();
 }

--- a/python-parser/Cargo.toml
+++ b/python-parser/Cargo.toml
@@ -14,4 +14,4 @@ log = "0.3"
 env_logger = "0.3"
 
 [build-dependencies]
-syslog-ng-build = "0.2"
+syslog-ng-build = { path = "../syslog-ng-rs/syslog-ng-build" }

--- a/python-parser/Cargo.toml
+++ b/python-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "python-parser"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Tibor Benke <ihrwein@gmail.com>"]
 build = "build.rs"
 

--- a/python-parser/src/utils.rs
+++ b/python-parser/src/utils.rs
@@ -1,4 +1,4 @@
-use syslog_ng_common::{ParserBuilder, mock, GlobalConfig};
+use syslog_ng_common::{ParserBuilder, GlobalConfig};
 
 use PythonParser;
 use PythonParserBuilder;
@@ -6,7 +6,7 @@ use PythonParserBuilder;
 pub fn build_parser_with_options(module_name: &str,
                                  class_name: &str,
                                  options: &[(&str, &str)])
-                                 -> PythonParser<mock::MockPipe> {
+                                 -> PythonParser {
     let cfg = GlobalConfig::new(0x0308);
     let mut builder = PythonParserBuilder::new(cfg);
     builder.option(::options::MODULE.to_owned(), module_name.to_owned()).ok().unwrap();
@@ -17,6 +17,6 @@ pub fn build_parser_with_options(module_name: &str,
     builder.build().unwrap()
 }
 
-pub fn build_parser(module_name: &str, class_name: &str) -> PythonParser<mock::MockPipe> {
+pub fn build_parser(module_name: &str, class_name: &str) -> PythonParser {
     build_parser_with_options(module_name, class_name, &[])
 }

--- a/python-parser/tests/logging.rs
+++ b/python-parser/tests/logging.rs
@@ -6,7 +6,6 @@ extern crate log;
 use std::env;
 use python_parser::{options, PythonParserBuilder};
 use syslog_ng_common::{ParserBuilder, SYSLOG_NG_INITIALIZED, syslog_ng_global_init, GlobalConfig};
-use syslog_ng_common::mock::MockPipe;
 use log::{LogRecord, LogLevel, LogMetadata};
 
 use std::sync::Arc;
@@ -65,7 +64,7 @@ fn logging_callbacks_can_be_used_from_init_method(messages: Arc<Mutex<Vec<Simpli
                     SimplifiedLogRecord::new(LogLevel::Error, "ERROR"),
                     SimplifiedLogRecord::new(LogLevel::Debug, "DEBUG")];
     let cfg = GlobalConfig::new(0x0308);
-    let mut builder = PythonParserBuilder::<MockPipe>::new(cfg);
+    let mut builder = PythonParserBuilder::new(cfg);
     builder.option(options::MODULE.to_owned(), "_test_module".to_owned()).ok().unwrap();
     builder.option(options::CLASS.to_owned(),
                 "LoggingIsUsedInInitMethod".to_owned())
@@ -92,7 +91,7 @@ fn logging_callbacks_are_not_overriden_if_they_are_already_defined(messages: Arc
                     SimplifiedLogRecord::new(LogLevel::Warn,
                                              "Already implemented debug() function, omitting callback definition.")];
     let cfg = GlobalConfig::new(0x0308);
-    let mut builder = PythonParserBuilder::<MockPipe>::new(cfg);
+    let mut builder = PythonParserBuilder::new(cfg);
     builder.option(options::MODULE.to_owned(),
                 "_test_module.test_logging".to_owned())
         .ok()

--- a/python-parser/tests/parser.rs
+++ b/python-parser/tests/parser.rs
@@ -37,7 +37,7 @@ fn test_error_is_returned_if_there_is_no_parse_method() {
     let gil = Python::acquire_gil();
     let py = gil.python();
     let result = call_parse(py, TEST_MODULE_NAME, "ParseMethodReturnsNotBoolean").unwrap();
-    let _ = PythonParser::<MockPipe>::process_parse_result(py, result).err().unwrap();
+    let _ = PythonParser::process_parse_result(py, result).err().unwrap();
 }
 
 #[test]
@@ -47,7 +47,7 @@ fn test_parse_method_which_returns_boolean_does_not_raise_errors() {
     let gil = Python::acquire_gil();
     let py = gil.python();
     let result = call_parse(py, TEST_MODULE_NAME, "ParserClassWithGoodParseMethod").unwrap();
-    let _ = PythonParser::<MockPipe>::process_parse_result(py, result).unwrap();
+    let _ = PythonParser::process_parse_result(py, result).unwrap();
 }
 
 #[test]

--- a/python-parser/tests/parser_builder.rs
+++ b/python-parser/tests/parser_builder.rs
@@ -6,7 +6,6 @@ extern crate env_logger;
 use std::env;
 use python_parser::{PythonParserBuilder, options};
 use syslog_ng_common::{ParserBuilder, SYSLOG_NG_INITIALIZED, syslog_ng_global_init, GlobalConfig};
-use syslog_ng_common::mock::MockPipe;
 use cpython::{Python, PyDict};
 
 const TEST_MODULE_NAME: &'static str = "_test_module";
@@ -17,7 +16,7 @@ fn test_exising_module_can_be_imported() {
     env::set_var("PYTHONPATH", env::current_dir().unwrap());
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let _ = PythonParserBuilder::<MockPipe>::load_module(py, TEST_MODULE_NAME).unwrap();
+    let _ = PythonParserBuilder::load_module(py, TEST_MODULE_NAME).unwrap();
 }
 
 #[test]
@@ -26,7 +25,7 @@ fn test_non_exising_module_cannot_be_imported() {
     env::set_var("PYTHONPATH", env::current_dir().unwrap());
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let _ = PythonParserBuilder::<MockPipe>::load_module(py, "__non_existing_python_module_name").err().unwrap();
+    let _ = PythonParserBuilder::load_module(py, "__non_existing_python_module_name").err().unwrap();
 }
 
 #[test]
@@ -35,8 +34,8 @@ fn test_existing_class_be_imported_from_module() {
     env::set_var("PYTHONPATH", env::current_dir().unwrap());
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let module = PythonParserBuilder::<MockPipe>::load_module(py, TEST_MODULE_NAME).unwrap();
-    let _ = PythonParserBuilder::<MockPipe>::load_class(py, &module, "ExistingParser").unwrap();
+    let module = PythonParserBuilder::load_module(py, TEST_MODULE_NAME).unwrap();
+    let _ = PythonParserBuilder::load_class(py, &module, "ExistingParser").unwrap();
 }
 
 #[test]
@@ -45,8 +44,8 @@ fn test_non_exising_class_cannot_be_imported() {
     env::set_var("PYTHONPATH", env::current_dir().unwrap());
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let module = PythonParserBuilder::<MockPipe>::load_module(py, TEST_MODULE_NAME).unwrap();
-    let _ = PythonParserBuilder::<MockPipe>::load_class(py, &module, "NonExistingParser").err().unwrap();
+    let module = PythonParserBuilder::load_module(py, TEST_MODULE_NAME).unwrap();
+    let _ = PythonParserBuilder::load_class(py, &module, "NonExistingParser").err().unwrap();
 }
 
 #[test]
@@ -55,9 +54,9 @@ fn test_parser_class_is_callable() {
     env::set_var("PYTHONPATH", env::current_dir().unwrap());
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let module = PythonParserBuilder::<MockPipe>::load_module(py, TEST_MODULE_NAME).unwrap();
-    let class = PythonParserBuilder::<MockPipe>::load_class(py, &module, "CallableClass").unwrap();
-    let _ = PythonParserBuilder::<MockPipe>::instantiate_class(py, &class).unwrap();
+    let module = PythonParserBuilder::load_module(py, TEST_MODULE_NAME).unwrap();
+    let class = PythonParserBuilder::load_class(py, &module, "CallableClass").unwrap();
+    let _ = PythonParserBuilder::instantiate_class(py, &class).unwrap();
 }
 
 #[test]
@@ -66,9 +65,9 @@ fn test_not_callable_object_cannot_be_instantiated() {
     env::set_var("PYTHONPATH", env::current_dir().unwrap());
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let module = PythonParserBuilder::<MockPipe>::load_module(py, TEST_MODULE_NAME).unwrap();
-    let class = PythonParserBuilder::<MockPipe>::load_class(py, &module, "NotCallableObject").unwrap();
-    let _ = PythonParserBuilder::<MockPipe>::instantiate_class(py, &class).err().unwrap();
+    let module = PythonParserBuilder::load_module(py, TEST_MODULE_NAME).unwrap();
+    let class = PythonParserBuilder::load_class(py, &module, "NotCallableObject").unwrap();
+    let _ = PythonParserBuilder::instantiate_class(py, &class).err().unwrap();
 }
 
 #[test]
@@ -77,10 +76,10 @@ fn test_init_is_called_if_it_exists() {
     env::set_var("PYTHONPATH", env::current_dir().unwrap());
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let module = PythonParserBuilder::<MockPipe>::load_module(py, TEST_MODULE_NAME).unwrap();
-    let class = PythonParserBuilder::<MockPipe>::load_class(py, &module, "ClassWithInitMethod").unwrap();
-    let instance = PythonParserBuilder::<MockPipe>::instantiate_class(py, &class).unwrap();
-    let _ = PythonParserBuilder::<MockPipe>::initialize_instance(py, &instance, PyDict::new(py)).unwrap();
+    let module = PythonParserBuilder::load_module(py, TEST_MODULE_NAME).unwrap();
+    let class = PythonParserBuilder::load_class(py, &module, "ClassWithInitMethod").unwrap();
+    let instance = PythonParserBuilder::instantiate_class(py, &class).unwrap();
+    let _ = PythonParserBuilder::initialize_instance(py, &instance, PyDict::new(py)).unwrap();
 }
 
 #[test]
@@ -89,10 +88,10 @@ fn test_parser_may_not_have_init_method() {
     env::set_var("PYTHONPATH", env::current_dir().unwrap());
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let module = PythonParserBuilder::<MockPipe>::load_module(py, TEST_MODULE_NAME).unwrap();
-    let class = PythonParserBuilder::<MockPipe>::load_class(py, &module, "InitMethodReturnsNotNone").unwrap();
-    let instance = PythonParserBuilder::<MockPipe>::instantiate_class(py, &class).unwrap();
-    let _ = PythonParserBuilder::<MockPipe>::initialize_instance(py, &instance, PyDict::new(py)).err().unwrap();
+    let module = PythonParserBuilder::load_module(py, TEST_MODULE_NAME).unwrap();
+    let class = PythonParserBuilder::load_class(py, &module, "InitMethodReturnsNotNone").unwrap();
+    let instance = PythonParserBuilder::instantiate_class(py, &class).unwrap();
+    let _ = PythonParserBuilder::initialize_instance(py, &instance, PyDict::new(py)).err().unwrap();
 }
 
 #[test]
@@ -101,10 +100,10 @@ fn test_init_must_return_nothing() {
     env::set_var("PYTHONPATH", env::current_dir().unwrap());
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let module = PythonParserBuilder::<MockPipe>::load_module(py, TEST_MODULE_NAME).unwrap();
-    let class = PythonParserBuilder::<MockPipe>::load_class(py, &module, "ParserWithoutInitMethod").unwrap();
-    let instance = PythonParserBuilder::<MockPipe>::instantiate_class(py, &class).unwrap();
-    let _ = PythonParserBuilder::<MockPipe>::initialize_instance(py, &instance, PyDict::new(py)).unwrap();
+    let module = PythonParserBuilder::load_module(py, TEST_MODULE_NAME).unwrap();
+    let class = PythonParserBuilder::load_class(py, &module, "ParserWithoutInitMethod").unwrap();
+    let instance = PythonParserBuilder::instantiate_class(py, &class).unwrap();
+    let _ = PythonParserBuilder::initialize_instance(py, &instance, PyDict::new(py)).unwrap();
 }
 
 #[test]
@@ -114,20 +113,20 @@ fn test_module_loading_and_class_initialization() {
     let gil = Python::acquire_gil();
     let py = gil.python();
     let options = [];
-    let _ = PythonParserBuilder::<MockPipe>::load_and_init_class(py,
+    let _ = PythonParserBuilder::load_and_init_class(py,
                                                                  "__non_existing_python_module_name",
                                                                  "ExistingParser",
                                                                  &options)
         .err()
         .unwrap();
-    let _ = PythonParserBuilder::<MockPipe>::load_and_init_class(py, TEST_MODULE_NAME, "NonExistingParser", &options)
+    let _ = PythonParserBuilder::load_and_init_class(py, TEST_MODULE_NAME, "NonExistingParser", &options)
         .err()
         .unwrap();
-    let _ = PythonParserBuilder::<MockPipe>::load_and_init_class(py, TEST_MODULE_NAME, "ExistingParser", &options)
+    let _ = PythonParserBuilder::load_and_init_class(py, TEST_MODULE_NAME, "ExistingParser", &options)
         .unwrap();
-    let _ = PythonParserBuilder::<MockPipe>::load_and_init_class(py, TEST_MODULE_NAME, "ClassWithInitMethod", &options)
+    let _ = PythonParserBuilder::load_and_init_class(py, TEST_MODULE_NAME, "ClassWithInitMethod", &options)
         .unwrap();
-    let _ = PythonParserBuilder::<MockPipe>::load_and_init_class(py,
+    let _ = PythonParserBuilder::load_and_init_class(py,
                                                                  TEST_MODULE_NAME,
                                                                  "InitMethodReturnsNotNone",
                                                                  &options)
@@ -144,7 +143,7 @@ fn test_parser_can_be_built_if_there_is_no_error() {
         }
     });
     let cfg = GlobalConfig::new(0x0308);
-    let mut builder = PythonParserBuilder::<MockPipe>::new(cfg);
+    let mut builder = PythonParserBuilder::new(cfg);
     builder.option(options::MODULE.to_owned(), "_test_module".to_owned()).ok().unwrap();
     builder.option(options::CLASS.to_owned(), "ExistingParser".to_owned()).ok().unwrap();
     let _ = builder.build().unwrap();
@@ -159,7 +158,7 @@ fn test_parser_cannot_be_built_if_there_is_an_error() {
         }
     });
     let cfg = GlobalConfig::new(0x0308);
-    let mut builder = PythonParserBuilder::<MockPipe>::new(cfg);
+    let mut builder = PythonParserBuilder::new(cfg);
     builder.option(options::MODULE.to_owned(), "_test_module".to_owned()).ok().unwrap();
     builder.option(options::CLASS.to_owned(), "NonExistingParser".to_owned()).ok().unwrap();
     let _ = builder.build().err().unwrap();
@@ -174,7 +173,7 @@ fn test_exception_is_raised_in_init_method() {
         }
     });
     let cfg = GlobalConfig::new(0x0308);
-    let mut builder = PythonParserBuilder::<MockPipe>::new(cfg);
+    let mut builder = PythonParserBuilder::new(cfg);
     builder.option(options::MODULE.to_owned(), "_test_module".to_owned()).ok().unwrap();
     builder.option(options::CLASS.to_owned(),
                 "ExceptionIsRaisedInInitMethod".to_owned())

--- a/regex-parser/Cargo.toml
+++ b/regex-parser/Cargo.toml
@@ -13,4 +13,4 @@ regex = "0.1"
 log = "0.3"
 
 [build-dependencies]
-syslog-ng-build = "0.2"
+syslog-ng-build = { path = "../syslog-ng-rs/syslog-ng-build" }

--- a/regex-parser/Cargo.toml
+++ b/regex-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "regex-parser"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Tibor Benke <ihrwein@gmail.com>"]
 build = "build.rs"
 

--- a/regex-parser/src/lib.rs
+++ b/regex-parser/src/lib.rs
@@ -4,7 +4,6 @@ extern crate syslog_ng_common;
 extern crate log;
 extern crate regex;
 
-use std::marker::PhantomData;
 use syslog_ng_common::{LogMessage, Parser, ParserBuilder, Error, Pipe, GlobalConfig};
 use regex::Regex;
 
@@ -19,24 +18,22 @@ pub struct RegexParser {
     pub regex: Regex,
 }
 
-pub struct RegexParserBuilder<P: Pipe> {
+pub struct RegexParserBuilder {
     regex: Option<Regex>,
-    _marker: PhantomData<P>
 }
 
-impl<P> Clone for RegexParserBuilder<P> where P: Pipe {
+impl Clone for RegexParserBuilder {
     fn clone(&self) -> Self {
         RegexParserBuilder {
             regex: self.regex.clone(),
-            _marker: PhantomData
         }
     }
 }
 
-impl<P: Pipe> ParserBuilder<P> for RegexParserBuilder<P> {
+impl ParserBuilder for RegexParserBuilder {
     type Parser = RegexParser;
     fn new(_: GlobalConfig) -> Self {
-        RegexParserBuilder { regex: None, _marker: PhantomData }
+        RegexParserBuilder { regex: None }
     }
     fn option(&mut self, name: String, value: String) -> Result<(), Error> {
         if name == REGEX_OPTION {
@@ -59,8 +56,8 @@ impl<P: Pipe> ParserBuilder<P> for RegexParserBuilder<P> {
     }
 }
 
-impl<P: Pipe> Parser<P> for RegexParser {
-    fn parse(&mut self, _: &mut P, logmsg: &mut LogMessage, input: &str) -> bool {
+impl Parser for RegexParser {
+    fn parse(&mut self, _: &mut Pipe, logmsg: &mut LogMessage, input: &str) -> bool {
         if let Some(captures) = self.regex.captures(input) {
             for (name, value) in captures.iter_named() {
                 if let Some(value) = value {
@@ -74,4 +71,4 @@ impl<P: Pipe> Parser<P> for RegexParser {
     }
 }
 
-parser_plugin!(RegexParserBuilder<LogParser>);
+parser_plugin!(RegexParserBuilder);

--- a/regex-parser/src/tests.rs
+++ b/regex-parser/src/tests.rs
@@ -59,7 +59,7 @@ fn test_parser_can_be_built_with_valid_regex() {
         }
     });
     let cfg = GlobalConfig::new(0x0308);
-    let mut builder = RegexParserBuilder::<mock::MockPipe>::new(cfg);
+    let mut builder = RegexParserBuilder::new(cfg);
     builder.option(REGEX_OPTION.to_string(), "[abc]d".to_string()).ok().unwrap();
     let _ = builder.build().unwrap();
 }
@@ -72,7 +72,7 @@ fn test_parser_cannot_be_built_with_invalid_regex() {
         }
     });
     let cfg = GlobalConfig::new(0x0308);
-    let mut builder = RegexParserBuilder::<mock::MockPipe>::new(cfg);
+    let mut builder = RegexParserBuilder::new(cfg);
     builder.option(REGEX_OPTION.to_string(), "[abcd".to_string()).err().unwrap();
     if let Error::MissingRequiredOption(value) = builder.build().err().unwrap() {
         assert_eq!(REGEX_OPTION, value);

--- a/syslog-ng-rs/syslog-ng-build/Cargo.toml
+++ b/syslog-ng-rs/syslog-ng-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-ng-build"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Tibor Benke <ihrwein@gmail.com>"]
 homepage = "https://github.com/ihrwein/syslog-ng-rs"
 repository = "https://github.com/ihrwein/syslog-ng-rs"

--- a/syslog-ng-rs/syslog-ng-build/src/lib.rs
+++ b/syslog-ng-rs/syslog-ng-build/src/lib.rs
@@ -135,6 +135,14 @@ fn link_against_module(content: &str) {
     compile_and_link_module(&dest_path);
 }
 
+/// Generates a module for syslog-ng.
+///
+/// This method generates code which describes a syslog-ng module. A module has a `canonical_name`
+/// (like `"foo"`), a `description` (like "This module contains plugins to ....") and an optional
+/// parser plugin. `parser_name` represents the name of the parser, if it's `None` the module
+/// doesn't contain any plugin.
+///
+/// This method must be called in a build script (`build.rs`).
 pub fn create_module(canonical_name: &str, description: &str, parser_name: Option<&str>) {
     link_against_rust_deps();
     let module_content = create_module_content(canonical_name, description, parser_name);

--- a/syslog-ng-rs/syslog-ng-build/src/lib.rs
+++ b/syslog-ng-rs/syslog-ng-build/src/lib.rs
@@ -112,6 +112,7 @@ fn compile_and_link_module<P: AsRef<Path>>(dest_path: P) {
             }
 
             compiler.flag("-c")
+                    .flag("-std=gnu99")
                     .file(dest_path)
                     .compile("librust-module.a");
         }

--- a/syslog-ng-rs/syslog-ng-build/src/lib.rs
+++ b/syslog-ng-rs/syslog-ng-build/src/lib.rs
@@ -118,6 +118,7 @@ fn compile_and_link_module<P: AsRef<Path>>(dest_path: P) {
         }
         Err(err) => {
             println!("{}", err);
+            ::std::process::exit(1);
         }
     }
 }

--- a/syslog-ng-rs/syslog-ng-common/Cargo.toml
+++ b/syslog-ng-rs/syslog-ng-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syslog-ng-common"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Tibor Benke <ihrwein@gmail.com>"]
 homepage = "https://github.com/ihrwein/syslog-ng-rs"
 repository = "https://github.com/ihrwein/syslog-ng-rs"

--- a/syslog-ng-rs/syslog-ng-common/src/cfg.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/cfg.rs
@@ -32,19 +32,6 @@ impl GlobalConfig {
     }
 
     /// Returns the configuration's user version.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use syslog_ng_common::{SYSLOG_NG_INITIALIZED, syslog_ng_global_init};
-    /// # use syslog_ng_common::GlobalConfig;
-
-    /// # SYSLOG_NG_INITIALIZED.call_once(|| {
-    /// #     unsafe { syslog_ng_global_init() };
-    /// # });
-    ///   let cfg = GlobalConfig::new(0x0308);
-    ///   assert_eq!(cfg.get_user_version(), (3, 8));
-    /// ```
     pub fn get_user_version(&self) -> (u8, u8) {
         let ptr = self.raw_ptr();
         let mut version = unsafe { cfg::cfg_get_user_version(ptr) };
@@ -58,19 +45,6 @@ impl GlobalConfig {
     }
 
     /// Returns the configuration's parsed version.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use syslog_ng_common::{SYSLOG_NG_INITIALIZED, syslog_ng_global_init};
-    /// # use syslog_ng_common::GlobalConfig;
-
-    /// # SYSLOG_NG_INITIALIZED.call_once(|| {
-    /// #     unsafe { syslog_ng_global_init() };
-    /// # });
-    ///   let cfg = GlobalConfig::new(0x0308);
-    ///   assert_eq!(cfg.get_parsed_version(), (0, 0));
-    /// ```
     pub fn get_parsed_version(&self) -> (u8, u8) {
         let ptr = self.raw_ptr();
         let mut version = unsafe { cfg::cfg_get_parsed_version(ptr) };

--- a/syslog-ng-rs/syslog-ng-common/src/formatter.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/formatter.rs
@@ -22,8 +22,8 @@ impl MessageFormatter {
         }
     }
 
-    pub fn set_prefix(&mut self, prefix: String) {
-        self.prefix = Some(prefix)
+    pub fn set_prefix<S: Into<String>>(&mut self, prefix: S) {
+        self.prefix = Some(prefix.into());
     }
 
     pub fn format<'a, 'b, 'c>(&'a mut self, key: &'b str, value: &'c str) -> (&'a str, &'c str) {

--- a/syslog-ng-rs/syslog-ng-common/src/formatter.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/formatter.rs
@@ -9,15 +9,6 @@
 use std::fmt::Write;
 
 /// Applies transformations to key-value pairs.
-///
-/// # Examples
-/// ```
-/// # use syslog_ng_common::MessageFormatter;
-///
-/// let mut formatter = MessageFormatter::new();
-/// formatter.set_prefix("foo.");
-/// assert_eq!(formatter.format("key", "value"), ("foo.key", "value"));
-/// ```
 #[derive(Clone)]
 pub struct MessageFormatter {
     buffer: String,

--- a/syslog-ng-rs/syslog-ng-common/src/formatter.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/formatter.rs
@@ -8,24 +8,35 @@
 
 use std::fmt::Write;
 
+/// Applies transformations to key-value pairs.
+///
+/// # Examples
+/// ```
+/// # use syslog_ng_common::MessageFormatter;
+///
+/// let mut formatter = MessageFormatter::new();
+/// formatter.set_prefix("foo.");
+/// assert_eq!(formatter.format("key", "value"), ("foo.key", "value"));
+/// ```
 #[derive(Clone)]
 pub struct MessageFormatter {
     buffer: String,
     prefix: Option<String>,
 }
-
 impl MessageFormatter {
+    /// Creates a new MessageFormatter without any transformations.
     pub fn new() -> MessageFormatter {
         MessageFormatter {
             buffer: String::new(),
             prefix: None,
         }
     }
-
+    /// Sets a `prefix` is applied to every `key` during a `format()` call.
     pub fn set_prefix<S: Into<String>>(&mut self, prefix: S) {
         self.prefix = Some(prefix.into());
     }
 
+    /// Formats the given `key` and/or `value` parameters and returns the formatted pair as a tuple.
     pub fn format<'a, 'b, 'c>(&'a mut self, key: &'b str, value: &'c str) -> (&'a str, &'c str) {
         self.buffer.clear();
         self.apply_prefix(key);

--- a/syslog-ng-rs/syslog-ng-common/src/lib.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/lib.rs
@@ -47,9 +47,24 @@ pub use logpipe::{LogPipe, Pipe};
 pub use logtemplate::{LogTemplate, LogTemplateOptions, LogTimeZone};
 pub use plugin::Plugin;
 
+/// This variable helps to initialize syslog-ng in tests.
+///
+/// # Examples
+///
+/// ```
+/// # use syslog_ng_common::SYSLOG_NG_INITIALIZED;
+/// # use syslog_ng_common::syslog_ng_global_init;
+/// SYSLOG_NG_INITIALIZED.call_once(|| {
+///     unsafe { syslog_ng_global_init() };
+/// })
+/// ```
 #[allow(dead_code)]
 pub static SYSLOG_NG_INITIALIZED: Once = ONCE_INIT;
 
+/// Initiales global variables in syslog-ng.
+///
+/// This function is uses only in tests. It mayn't contain everything what you need. If you add bindings
+/// for new types and you receive segmentation faults in tests, look for uninitialized globals.
 pub unsafe fn syslog_ng_global_init() {
     use syslog_ng_sys::resolved_configurable_paths as c_paths;
 
@@ -60,6 +75,7 @@ pub unsafe fn syslog_ng_global_init() {
     syslog_ng_sys::messages::msg_init(1 as c_int);
 }
 
+/// Aborts the process.
 pub fn commit_suicide() -> ! {
     unsafe {
         abort();

--- a/syslog-ng-rs/syslog-ng-common/src/lib.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/lib.rs
@@ -48,16 +48,6 @@ pub use logtemplate::{LogTemplate, LogTemplateOptions, LogTimeZone};
 pub use plugin::Plugin;
 
 /// This variable helps to initialize syslog-ng in tests.
-///
-/// # Examples
-///
-/// ```
-/// # use syslog_ng_common::SYSLOG_NG_INITIALIZED;
-/// # use syslog_ng_common::syslog_ng_global_init;
-/// SYSLOG_NG_INITIALIZED.call_once(|| {
-///     unsafe { syslog_ng_global_init() };
-/// })
-/// ```
 #[allow(dead_code)]
 pub static SYSLOG_NG_INITIALIZED: Once = ONCE_INIT;
 

--- a/syslog-ng-rs/syslog-ng-common/src/logger.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/logger.rs
@@ -11,6 +11,7 @@ use messages::{InternalMessageSender, Msg};
 
 use log;
 
+/// Initializes the logging subsystem to use syslog-ng's internal logs as backend.
 pub fn init_logger() {
     let _ = log::set_logger(|max_log_level| {
         max_log_level.set(InternalLogger::level());
@@ -18,10 +19,11 @@ pub fn init_logger() {
     });
 }
 
-
+/// Sends logs into syslog-ng's internal log stream.
 pub struct InternalLogger;
 
 impl InternalLogger {
+    /// Creates a log filter based on the current log level of syslog-ng.
     pub fn level() -> LogLevelFilter {
         InternalMessageSender::level()
     }

--- a/syslog-ng-rs/syslog-ng-common/src/logparser.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/logparser.rs
@@ -11,9 +11,11 @@ use Pipe;
 use LogPipe;
 use LogMessage;
 
+/// High level wrapper around syslog-ng's LogParser structure.
 pub struct LogParser(*mut syslog_ng_sys::LogParser);
 
 impl LogParser {
+    /// Wraps syslog-ng's raw LogParser pointer into this high level wrapper.
     pub fn wrap_raw(raw: *mut syslog_ng_sys::LogParser) -> LogParser {
         LogParser(raw)
     }

--- a/syslog-ng-rs/syslog-ng-common/src/logpipe.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/logpipe.rs
@@ -4,10 +4,12 @@ use LogMessage;
 use syslog_ng_sys::logpipe::__log_pipe_forward_msg;
 use syslog_ng_sys::LogPathOptions;
 
+/// `Pipe` is used to represent a log pipe which is able to forward log messages to other pipes.
 pub trait Pipe {
     fn forward(&mut self, msg: LogMessage);
 }
 
+/// High level wrapper around syslog-ng's raw LogPipe pointer.
 pub struct LogPipe(pub *mut syslog_ng_sys::LogPipe);
 
 impl Pipe for LogPipe {

--- a/syslog-ng-rs/syslog-ng-common/src/messages.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/messages.rs
@@ -10,7 +10,7 @@ use std::ffi::CString;
 use log::{LogLevel, LogLevelFilter};
 use syslog_ng_sys::messages;
 
-
+/// `Msg` represents the log levels and their numeric values.
 pub enum Msg {
     _Fatal = 2,
     Error = 3,
@@ -32,9 +32,11 @@ impl From<LogLevel> for Msg {
     }
 }
 
+/// `InternalMessageSender` is able to place log messages into syslog-ng's internal log stream.
 pub struct InternalMessageSender;
 
 impl InternalMessageSender {
+    /// Logs `message` with the given `severity` into syslog-ng's internal logs.
     pub fn create_and_send(severity: Msg, message: String) {
         unsafe {
             let msg = CString::new(message).unwrap();
@@ -44,6 +46,7 @@ impl InternalMessageSender {
         };
     }
 
+    /// Returns a `LogLevelFilter` based on syslog-ng's current log level.
     pub fn level() -> LogLevelFilter {
         if messages::trace_flag != 0 {
             LogLevelFilter::Trace

--- a/syslog-ng-rs/syslog-ng-common/src/mock.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/mock.rs
@@ -1,17 +1,24 @@
+//! Contains mock types to lessen the coupling with syslog-ng.
+
 use Pipe;
 use LogMessage;
 
+/// Type useful for mocking any `Pipe`.
+///
+/// It will store the messages in an internal vector.
 pub struct MockPipe{
     pub forwarded_messages: Vec<LogMessage>
 }
 
 impl MockPipe {
+    /// Creates a new `MockPipe`.
     pub fn new() -> MockPipe {
         MockPipe{ forwarded_messages: Vec::new()}
     }
 }
 
 impl Pipe for MockPipe {
+    /// Stores the messages in the internal vector.
     fn forward(&mut self, msg: LogMessage) {
         self.forwarded_messages.push(msg);
     }

--- a/syslog-ng-rs/syslog-ng-common/src/plugin.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/plugin.rs
@@ -4,8 +4,16 @@ use syslog_ng_sys;
 
 use std::ffi::CString;
 
+/// Represents a syslog-ng plugin.
 pub struct Plugin;
 
+/// Loads the plugin with `name`.
+///
+/// Returns `true` on successful loading, otherwise `false`.
+///
+/// # Panics
+///
+/// `name` must not contain any `\0` bytes.
 impl Plugin {
     pub fn load_module(name: &str, cfg: &mut GlobalConfig) -> bool {
         let name = CString::new(name).unwrap();

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/mod.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/mod.rs
@@ -6,5 +6,6 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+/// Types for implementing a parser (in syslog-ng's terminology).
 #[macro_use]
 pub mod parser;

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/error.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/error.rs
@@ -7,21 +7,29 @@
 // modified, or distributed except according to those terms.
 
 quick_error! {
+    /// Error type for configuration errors.
+    ///
+    /// This type is mainly used to indicate, that an `option(key, value)` was invalid (e.g.
+    /// `value` is a path but the file doesn't exist).
     #[derive(Debug)]
     pub enum Error {
+        /// A required option is missing.
         MissingRequiredOption(option: String) {
             description("A required option is missing")
             display("A required option is missing: {}", option)
         }
-
+        /// `value` from `option(key, value)` is invalid (e.g. non-existing file).
         InvalidValue(option_name: String, value: String, expected_value: String) {
             description("Invalid value in option")
             display("Invalid value in option. option_name={} value={} expected_value={}", option_name, value, expected_value)
         }
+        /// The specified configuration option is unknown. For example, you are only interested in
+        // `option("regex", XXX)` values, and the user specified `option("foo", "bar")`.
         UnknownOption(option_name: String) {
             description("Unknown configuration option")
             display("Unknown configuration option: option_name={}", option_name)
         }
+        /// Everything else.
         Verbatim(msg: String) {
             description(msg)
             display("{}", msg)
@@ -30,15 +38,55 @@ quick_error! {
 }
 
 impl Error {
+    /// Convenient constructor for `Error::MissingRequiredOption`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use syslog_ng_common::Error;
+    ///
+    /// let _ = Error::missing_required_option("foo");
+    /// let _ = Error::missing_required_option("bar".to_string());
+    /// ```
     pub fn missing_required_option<S: Into<String>>(option: S) -> Error {
         Error::MissingRequiredOption(option.into()).into()
     }
+    /// Convenient constructor for `Error::InvalidValue`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use syslog_ng_common::Error;
+    ///
+    /// let _ = Error::invalid_value("option_name", "option_value", "URL");
+    /// let _ = Error::invalid_value("option_name".to_string(), "option_value".to_string(), "URL".to_string());
+    /// ```
     pub fn invalid_value<S: Into<String>>(option_name: S, value: S, expected_value: S) -> Error {
         Error::InvalidValue(option_name.into(), value.into(), expected_value.into()).into()
     }
+    /// Convenient constructor for `Error::Verbatim`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use syslog_ng_common::Error;
+    ///
+    /// let _ = Error::verbatim_error("error message");
+    /// let _ = Error::verbatim_error("error message".to_string());
+    /// ```
     pub fn verbatim_error<S: Into<String>>(error_msg: S) -> Error {
         Error::Verbatim(error_msg.into()).into()
     }
+    /// Convenient constructor for `Error::UnknownOption`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use syslog_ng_common::Error;
+    ///
+    /// let _ = Error::unknown_option("foo");
+    /// let _ = Error::unknown_option("bar".to_string());
+    /// ```
     pub fn unknown_option<S: Into<String>>(option_name: S) -> Error {
         Error::UnknownOption(option_name.into()).into()
     }

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/error.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/error.rs
@@ -39,54 +39,18 @@ quick_error! {
 
 impl Error {
     /// Convenient constructor for `Error::MissingRequiredOption`
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use syslog_ng_common::Error;
-    ///
-    /// let _ = Error::missing_required_option("foo");
-    /// let _ = Error::missing_required_option("bar".to_string());
-    /// ```
     pub fn missing_required_option<S: Into<String>>(option: S) -> Error {
         Error::MissingRequiredOption(option.into()).into()
     }
     /// Convenient constructor for `Error::InvalidValue`
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use syslog_ng_common::Error;
-    ///
-    /// let _ = Error::invalid_value("option_name", "option_value", "URL");
-    /// let _ = Error::invalid_value("option_name".to_string(), "option_value".to_string(), "URL".to_string());
-    /// ```
     pub fn invalid_value<S: Into<String>>(option_name: S, value: S, expected_value: S) -> Error {
         Error::InvalidValue(option_name.into(), value.into(), expected_value.into()).into()
     }
     /// Convenient constructor for `Error::Verbatim`
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use syslog_ng_common::Error;
-    ///
-    /// let _ = Error::verbatim_error("error message");
-    /// let _ = Error::verbatim_error("error message".to_string());
-    /// ```
     pub fn verbatim_error<S: Into<String>>(error_msg: S) -> Error {
         Error::Verbatim(error_msg.into()).into()
     }
     /// Convenient constructor for `Error::UnknownOption`
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use syslog_ng_common::Error;
-    ///
-    /// let _ = Error::unknown_option("foo");
-    /// let _ = Error::unknown_option("bar".to_string());
-    /// ```
     pub fn unknown_option<S: Into<String>>(option_name: S) -> Error {
         Error::UnknownOption(option_name.into()).into()
     }

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
@@ -79,24 +79,6 @@ where F: UnwindSafe + FnOnce() -> R {
 ///
 /// It takes a `ParserBuilder` as its parameter and generates several functions. Only one `parser_plugin!`
 /// can be used in a compilation unit.
-///
-/// # Examples
-///
-/// ```
-/// # macro_rules! parser_plugin{
-/// #    ($name:ty) => {}
-/// # }
-/// #
-/// # use syslog_ng_common::ParserBuilder;
-/// #
-/// pub struct DummyParserBuilder;
-///
-/// //impl ParserBuilder for DummyParserBuilder {
-/// //    ...
-/// //}
-///
-/// parser_plugin!(DummyParserBuilder);
-/// ```
 #[macro_export]
 macro_rules! parser_plugin {
     ($name:ty) => {

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/mod.rs
@@ -28,9 +28,9 @@ use c_int;
 ///
 /// The parser instance is created when `build()` is called. It returns either a parser instance,
 /// or an error indicating why the building wasn't successful.
-pub trait ParserBuilder<P: Pipe>: Clone {
+pub trait ParserBuilder: Clone {
     /// Parser is the type that this builder implementation is able to build.
-    type Parser: Parser<P>;
+    type Parser: Parser;
     /// Creates a new `ParserBuilder` instance.
     fn new(GlobalConfig) -> Self;
     /// Sets a configuration option.
@@ -40,7 +40,7 @@ pub trait ParserBuilder<P: Pipe>: Clone {
 }
 
 /// The `Parser` trait is used to represent a `parser` according to syslog-ng's terminology.
-pub trait Parser<P: Pipe> {
+pub trait Parser {
     /// `init()` is called to indicate that the parser should be ready for log message processing.
     ///
     /// It is mainly used in conjunction with `deinit()`: the two methods shold be symmetrical. This
@@ -51,7 +51,7 @@ pub trait Parser<P: Pipe> {
     fn deinit(&mut self) -> bool { true }
     /// Parses `input` and inserts the new key-value pairs into `msg`. `pipe` represents the parent
     /// `LogPipe`. It can be mocked out to simplify the testing without syslog-ng.
-    fn parse(&mut self, pipe: &mut P, msg: &mut LogMessage, input: &str) -> bool;
+    fn parse(&mut self, pipe: &mut Pipe, msg: &mut LogMessage, input: &str) -> bool;
 }
 
 /// Converts a `bool` to a `c_int`

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
@@ -18,13 +18,13 @@ pub use proxies::parser::{Error, Parser, ParserBuilder};
 /// side as a `*mut ParserProxy` pointer.
 #[repr(C)]
 pub struct ParserProxy<B>
-    where B: ParserBuilder<LogParser>
+    where B: ParserBuilder
 {
     parser: Option<B::Parser>,
     builder: Option<B>,
 }
 
-impl<B> ParserProxy<B> where B: ParserBuilder<LogParser>
+impl<B> ParserProxy<B> where B: ParserBuilder
 {
     /// Creates a new `ParserProxy` instance and initializes a `ParserBuilder` internally.
     pub fn new(cfg: GlobalConfig) -> ParserProxy<B> {
@@ -115,7 +115,7 @@ impl<B> ParserProxy<B> where B: ParserBuilder<LogParser>
     }
 }
 
-impl<B> Clone for ParserProxy<B> where B: ParserBuilder<LogParser> {
+impl<B> Clone for ParserProxy<B> where B: ParserBuilder {
     fn clone(&self) -> ParserProxy<B> {
         ParserProxy {parser: None, builder: self.builder.clone()}
     }

--- a/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/proxies/parser/proxy.rs
@@ -12,6 +12,10 @@ use GlobalConfig;
 
 pub use proxies::parser::{Error, Parser, ParserBuilder};
 
+/// Handles the state of a parser.
+///
+/// `ParserProxy` hides the fact, that parsers are stateful objects. It is also passed to the C
+/// side as a `*mut ParserProxy` pointer.
 #[repr(C)]
 pub struct ParserProxy<B>
     where B: ParserBuilder<LogParser>
@@ -22,6 +26,7 @@ pub struct ParserProxy<B>
 
 impl<B> ParserProxy<B> where B: ParserBuilder<LogParser>
 {
+    /// Creates a new `ParserProxy` instance and initializes a `ParserBuilder` internally.
     pub fn new(cfg: GlobalConfig) -> ParserProxy<B> {
         ParserProxy {
             parser: None,
@@ -29,6 +34,7 @@ impl<B> ParserProxy<B> where B: ParserBuilder<LogParser>
         }
     }
 
+    /// Creates a new `ParserProxy` instance with the specific `builder` and `parser` values.
     pub fn with_builder_and_parser(builder: Option<B>,
                                    parser: Option<B::Parser>)
                                    -> ParserProxy<B> {
@@ -52,6 +58,11 @@ impl<B> ParserProxy<B> where B: ParserBuilder<LogParser>
         }
     }
 
+    /// Forwards the method call to either a `ParserBuilder` (as `build()`) or to a `Parser`
+    /// (as `init()`).
+    ///
+    /// Returns the result of either `build()` or `init()`. In case of an error, it's logged and
+    /// `false` is returned.
     pub fn init(&mut self) -> bool {
         if let Some(builder) = self.builder.take()  {
             return self.build_parser(builder);
@@ -64,6 +75,9 @@ impl<B> ParserProxy<B> where B: ParserBuilder<LogParser>
         }
     }
 
+    /// Forwards the method call to the wrapped `Parser`.
+    ///
+    /// Returns the forwarded result.
     pub fn deinit(&mut self) -> bool {
         if let Some(ref mut parser) = self.parser {
             parser.deinit()
@@ -72,6 +86,10 @@ impl<B> ParserProxy<B> where B: ParserBuilder<LogParser>
         }
     }
 
+    /// Calls `ParserBuilder`'s `option()` method.
+    ///
+    /// If `option()` returns an `Err`, an error is logged and `false` is returned, otherwise
+    /// `true`.
     pub fn set_option(&mut self, name: String, value: String) -> bool {
         let builder = self.builder.as_mut().expect("Failed to get builder on a ParserProxy");
 
@@ -84,6 +102,11 @@ impl<B> ParserProxy<B> where B: ParserBuilder<LogParser>
         }
     }
 
+    /// Calls the parser's `parse()` method.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `process()` is called without a built parser.
     pub fn process(&mut self, parent: &mut LogParser, msg: &mut LogMessage, input: &str) -> bool {
         self.parser
             .as_mut()

--- a/syslog-ng-rs/syslog-ng-common/src/sys.rs
+++ b/syslog-ng-rs/syslog-ng-common/src/sys.rs
@@ -6,6 +6,12 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+//! This module reexports some types from the `syslog_ng_sys` crate.
+//!
+//! The users of `syslog-ng-common` shouldn't use `syslog-ng-sys` directly, instead use the high
+//! level wrappers provided by `syslog-ng-common` (they don't have to define `syslog-ng-sys` as a
+//! dependency, since it's pulled in by syslog-ng-common). However, some functions are useful
+//! for the users of this crate, so they are reexported under this module.
 pub use syslog_ng_sys::LogMessage;
 pub use syslog_ng_sys::LogParser;
 pub use syslog_ng_sys::GlobalConfig;

--- a/syslog-ng-rs/syslog-ng-common/tests/dummy-parser.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/dummy-parser.rs
@@ -11,20 +11,19 @@ extern crate syslog_ng_common;
 #[macro_use]
 extern crate log;
 
-use std::marker::PhantomData;
 use std::ffi::CString;
 
-pub struct DummyParser;
+pub struct DummyParser {}
 
-pub struct DummyParserBuilder<P: Pipe>(PhantomData<P>);
+pub struct DummyParserBuilder {}
 
 use syslog_ng_common::LogMessage;
 use syslog_ng_common::{Parser, ParserBuilder, Error, Pipe, GlobalConfig};
 
-impl<P: Pipe> ParserBuilder<P> for DummyParserBuilder<P> {
+impl ParserBuilder for DummyParserBuilder {
     type Parser = DummyParser;
     fn new(_: GlobalConfig) -> Self {
-        DummyParserBuilder(PhantomData)
+        DummyParserBuilder{}
     }
     fn option(&mut self, name: String, value: String) -> Result<(), Error> {
         debug!("Setting option: {}={}", name, value);
@@ -35,28 +34,28 @@ impl<P: Pipe> ParserBuilder<P> for DummyParserBuilder<P> {
     }
     fn build(self) -> Result<Self::Parser, Error> {
         debug!("Building Rust parser");
-        Ok(DummyParser)
+        Ok(DummyParser{})
     }
 }
 
-impl<P: Pipe> Parser<P> for DummyParser {
-    fn parse(&mut self, _: &mut P, message: &mut LogMessage, input: &str) -> bool {
+impl Parser for DummyParser {
+    fn parse(&mut self, _: &mut Pipe, message: &mut LogMessage, input: &str) -> bool {
         debug!("Processing input in Rust Parser: {}", input);
         message.insert(&b"input"[..], input.as_bytes());
         true
     }
 }
 
-impl<P: Pipe> Clone for DummyParserBuilder<P> {
+impl Clone for DummyParserBuilder {
     fn clone(&self) -> Self {
-        DummyParserBuilder(PhantomData)
+        DummyParserBuilder{}
     }
 }
 
 // this verifies that the macro can be expanded
-parser_plugin!(DummyParserBuilder<LogParser>);
+parser_plugin!(DummyParserBuilder);
 
-use syslog_ng_common::{SYSLOG_NG_INITIALIZED, syslog_ng_global_init, ParserProxy, LogParser};
+use syslog_ng_common::{SYSLOG_NG_INITIALIZED, syslog_ng_global_init, ParserProxy};
 use syslog_ng_common::mock::MockPipe;
 
 #[test]
@@ -66,7 +65,7 @@ fn test_given_parser_implementation_when_it_receives_a_message_then_it_adds_a_sp
         unsafe { syslog_ng_global_init(); }
     });
     let cfg = GlobalConfig::new(0x0308);
-    let builder = DummyParserBuilder::<MockPipe>::new(cfg);
+    let builder = DummyParserBuilder::new(cfg);
     let mut parser = builder.build().ok().expect("Failed to build DummyParser");
     let mut msg = LogMessage::new();
     let input = "The quick brown ...";
@@ -82,7 +81,7 @@ fn test_parser_proxy_can_be_deinitialized() {
         unsafe { syslog_ng_global_init(); }
     });
     let cfg = GlobalConfig::new(0x0308);
-    let mut proxy = ParserProxy::<DummyParserBuilder<LogParser>>::new(cfg);
+    let mut proxy = ParserProxy::<DummyParserBuilder>::new(cfg);
     proxy.set_option("foo".to_owned(), "bar".to_owned());
     proxy.init();
     proxy.deinit();
@@ -94,7 +93,7 @@ use _parser_plugin::{native_parser_proxy_set_option};
 
 fn assert_option_setting_result_is_propagated(key: &str, expected: bool) {
     let mut proxy =
-        ParserProxy::with_builder_and_parser(Some(DummyParserBuilder(PhantomData)), None);
+        ParserProxy::with_builder_and_parser(Some(DummyParserBuilder{}), None);
     let key = CString::new(key).unwrap();
     let value = CString::new("value").unwrap();
     let actual = native_parser_proxy_set_option(&mut proxy, key.as_ptr(), value.as_ptr());

--- a/syslog-ng-rs/syslog-ng-common/tests/dummy-parser.rs
+++ b/syslog-ng-rs/syslog-ng-common/tests/dummy-parser.rs
@@ -14,7 +14,7 @@ extern crate log;
 use std::marker::PhantomData;
 use std::ffi::CString;
 
-pub struct DummyParser<P: Pipe>(PhantomData<P>);
+pub struct DummyParser;
 
 pub struct DummyParserBuilder<P: Pipe>(PhantomData<P>);
 
@@ -22,7 +22,7 @@ use syslog_ng_common::LogMessage;
 use syslog_ng_common::{Parser, ParserBuilder, Error, Pipe, GlobalConfig};
 
 impl<P: Pipe> ParserBuilder<P> for DummyParserBuilder<P> {
-    type Parser = DummyParser<P>;
+    type Parser = DummyParser;
     fn new(_: GlobalConfig) -> Self {
         DummyParserBuilder(PhantomData)
     }
@@ -35,11 +35,11 @@ impl<P: Pipe> ParserBuilder<P> for DummyParserBuilder<P> {
     }
     fn build(self) -> Result<Self::Parser, Error> {
         debug!("Building Rust parser");
-        Ok(DummyParser(PhantomData))
+        Ok(DummyParser)
     }
 }
 
-impl<P: Pipe> Parser<P> for DummyParser<P> {
+impl<P: Pipe> Parser<P> for DummyParser {
     fn parse(&mut self, _: &mut P, message: &mut LogMessage, input: &str) -> bool {
         debug!("Processing input in Rust Parser: {}", input);
         message.insert(&b"input"[..], input.as_bytes());

--- a/syslog-ng-rs/syslog-ng-sys/Cargo.toml
+++ b/syslog-ng-rs/syslog-ng-sys/Cargo.toml
@@ -15,7 +15,6 @@ name = "syslog_ng_sys"
 
 [dependencies]
 libc = "0.2"
-log = "0.3"
 glib-sys = "0.3.0"
 
 [build-dependencies]

--- a/syslog-ng-rs/syslog-ng-sys/build.rs
+++ b/syslog-ng-rs/syslog-ng-sys/build.rs
@@ -8,6 +8,8 @@
 
 extern crate pkg_config;
 
+use std::process::exit;
+
 fn main() {
     let res = pkg_config::find_library("syslog-ng");
     match res {
@@ -19,6 +21,7 @@ fn main() {
         },
         Err(err) => {
             println!("libsyslog-ng.so is not found by pkg-config: {}", err);
+            exit(1);
         }
     }
 }

--- a/syslog-ng-rs/syslog-ng-sys/src/lib.rs
+++ b/syslog-ng-rs/syslog-ng-sys/src/lib.rs
@@ -7,8 +7,6 @@
 // modified, or distributed except according to those terms.
 
 extern crate libc;
-#[macro_use]
-extern crate log;
 extern crate glib_sys;
 
 pub mod types;

--- a/syslog-ng-rs/syslog-ng-sys/src/logpipe.rs
+++ b/syslog-ng-rs/syslog-ng-sys/src/logpipe.rs
@@ -5,12 +5,16 @@ use types::c_int;
 pub struct LogPathOptions {
     pub ack_needed: c_int,
     pub flow_control_requested: c_int,
-    pub matched: *mut c_int
+    pub matched: *mut c_int,
 }
 
 impl Default for LogPathOptions {
     fn default() -> LogPathOptions {
-        LogPathOptions {ack_needed: 0, flow_control_requested: 0, matched: ::std::ptr::null_mut()}
+        LogPathOptions {
+            ack_needed: 0,
+            flow_control_requested: 0,
+            matched: ::std::ptr::null_mut(),
+        }
     }
 }
 
@@ -18,5 +22,7 @@ pub enum LogPipe {}
 
 #[link(name = "syslog-ng")]
 extern "C" {
-    pub fn __log_pipe_forward_msg(slf: *mut LogPipe, msg: *mut LogMessage, path_options: *const LogPathOptions);
+    pub fn __log_pipe_forward_msg(slf: *mut LogPipe,
+                                  msg: *mut LogMessage,
+                                  path_options: *const LogPathOptions);
 }

--- a/syslog-ng-rs/syslog-ng-sys/src/logtemplate.rs
+++ b/syslog-ng-rs/syslog-ng-sys/src/logtemplate.rs
@@ -15,15 +15,19 @@ pub enum LogTemplateOptions {}
 
 #[link(name = "syslog-ng")]
 extern "C" {
-   pub fn log_template_compile(slf: *mut LogTemplate, template: *const c_char, error: *mut *mut GError) -> c_int;
-   pub fn log_template_new(cfg: *const GlobalConfig, name: *const c_char) -> *mut LogTemplate;
-   pub fn log_template_format(slf: *const LogTemplate,
-                              lm: *const LogMessage,
-                              opts: *const LogTemplateOptions,
-                              tz: c_int,
-                              seq_num: i32,
-                              context_id: *const c_char,
-                              result: *mut GString) -> c_void;
+    pub fn log_template_compile(slf: *mut LogTemplate,
+                                template: *const c_char,
+                                error: *mut *mut GError)
+                                -> c_int;
+    pub fn log_template_new(cfg: *const GlobalConfig, name: *const c_char) -> *mut LogTemplate;
+    pub fn log_template_format(slf: *const LogTemplate,
+                               lm: *const LogMessage,
+                               opts: *const LogTemplateOptions,
+                               tz: c_int,
+                               seq_num: i32,
+                               context_id: *const c_char,
+                               result: *mut GString)
+                               -> c_void;
     pub fn log_template_unref(s: *mut LogTemplate);
     pub fn log_template_global_init();
     pub fn log_template_global_deinit();
@@ -34,5 +38,6 @@ extern "C" {
                                             tz: c_int,
                                             seq_num: i32,
                                             context_id: *const c_char,
-                                            result: *mut GString) -> c_void;
+                                            result: *mut GString)
+                                            -> c_void;
 }

--- a/syslog-ng-rs/syslog-ng-sys/src/plugin.rs
+++ b/syslog-ng-rs/syslog-ng-sys/src/plugin.rs
@@ -6,5 +6,8 @@ pub enum CfgArgs {}
 
 #[link(name = "syslog-ng")]
 extern "C" {
-   pub fn plugin_load_module(module_name: *const c_char, cfg: *mut GlobalConfig, cfg_args: *mut CfgArgs) -> c_int;
+    pub fn plugin_load_module(module_name: *const c_char,
+                              cfg: *mut GlobalConfig,
+                              cfg_args: *mut CfgArgs)
+                              -> c_int;
 }

--- a/syslog-ng-rs/syslog-ng-sys/src/resolved_configurable_paths.rs
+++ b/syslog-ng-rs/syslog-ng-sys/src/resolved_configurable_paths.rs
@@ -2,10 +2,10 @@ use c_char;
 
 #[repr(C)]
 pub struct ResolvedConfigurablePaths {
-  cfgfilename : *const c_char,
-  persist_file : *const c_char,
-  ctlfilename : *const c_char,
-  initial_module_path : *const c_char,
+    cfgfilename: *const c_char,
+    persist_file: *const c_char,
+    ctlfilename: *const c_char,
+    initial_module_path: *const c_char,
 }
 
 #[link(name = "syslog-ng")]


### PR DESCRIPTION
This PR contains the following changes:
* documenting `syslog-ng-common` crate
* documenting `syslog-ng-build` crate
* removing an unused dependency
* simplifying `DummyParser`
* removing `P: Pipe` bound from `Parser`
* extracting trait bounds into a trait in correlation-parser
* using the local `syslog-ng-build` crate

Documentation can be built with `cargo doc` and it can be opened with `cardo doc --open`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ihrwein/syslog-ng-rust-modules/40)
<!-- Reviewable:end -->
