### PR TITLE
regex-parser: use single quotes instead of escaping backslashes

### DIFF
--- a/regex-parser/README.md
+++ b/regex-parser/README.md
@@ -90,8 +90,7 @@ log {
     source(s_localhost);
     parser {
         regex-rs(
-            # Note the additional escaping before the backslashes!!!
-            option("regex", "seq: (?P<seq>\\d+), thread: (?P<thread>\\d+), runid: (?P<runid>\\d+), stamp: (?P<stamp>[^ ]+) (?P<padding>.*$)")
+            option("regex", 'seq: (?P<seq>\d+), thread: (?P<thread>\d+), runid: (?P<runid>\d+), stamp: (?P<stamp>[^ ]+) (?P<padding>.*$)')
         );
     };
     destination {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ihrwein/syslog-ng-rust-modules/42)
<!-- Reviewable:end -->
