### PR TITLE
Fix correlation in case of empty pattern list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
     - env: RUST_CHANNEL=stable TEST_MODE=cmake
   allow_failures:
     - env: RUST_CHANNEL=nightly TEST_MODE=everything TRAVIS_CARGO_NIGHTLY_FEATURE=nightly
+    - env: RUST_CHANNEL=beta TEST_MODE=everything
 
 git:
   submodules: false

--- a/correlation-parser/correlation/src/context/context_map.rs
+++ b/correlation-parser/correlation/src/context/context_map.rs
@@ -45,30 +45,26 @@ impl<E, T> ContextMap<E, T> where E: Event, T: Template<Event=E> {
 
     pub fn insert(&mut self, context: Context<E, T>) {
         self.contexts.push(context);
-        let last_context = self.contexts
-                               .last()
-                               .expect("Failed to remove the last Context from a non empty vector");
-        let index_of_last_context = self.contexts.len() - 1;
-        let patterns = last_context.patterns();
-        ContextMap::<E, T>::update_indices(&mut self.map, &mut self.empty_pattern_indices, index_of_last_context, patterns);
+        self.update_indices();
     }
 
-    fn update_indices(map: &mut HashMap<Vec<u8>, Vec<usize>>,
-                      empty_pattern_indices: &mut Vec<usize>,
-                      new_index: usize,
-                      patterns: &[String]) {
+    fn update_indices(&mut self) {
+        let index_of_last_context = self.contexts.len() - 1;
+        let patterns : Vec<String> = self.contexts.last().expect("Failed to remove the last Context from a non empty vector")
+                                         .patterns().iter().cloned().collect();
+
         if patterns.is_empty() {
-            empty_pattern_indices.push(new_index);
+            self.empty_pattern_indices.push(index_of_last_context);
         } else {
-            ContextMap::<E, T>::add_index_to_looked_up_index_vectors(map, new_index, patterns);
+            self.add_index_to_looked_up_index_vectors(index_of_last_context, &patterns);
         }
     }
 
-    fn add_index_to_looked_up_index_vectors(map: &mut HashMap<Vec<u8>, Vec<usize>>,
+    fn add_index_to_looked_up_index_vectors(&mut self,
                                             new_index: usize,
                                             patterns: &[String]) {
         for i in patterns {
-            map.entry(i.as_bytes().to_vec()).or_insert_with(Vec::new).push(new_index);
+            self.map.entry(i.as_bytes().to_vec()).or_insert_with(Vec::new).push(new_index);
         }
     }
 

--- a/correlation-parser/correlation/src/correlator/message.rs
+++ b/correlation-parser/correlation/src/correlator/message.rs
@@ -17,11 +17,9 @@ pub struct MessageEventHandler;
 impl<'a, E, T> EventHandler<E, SharedData<'a, E, T>> for MessageEventHandler where E: 'a + Event, T: Template<Event=E> {
     fn handle_event(&mut self, event: E, data: &mut SharedData<E, T>) {
         trace!("MessageEventHandler: handle_event()");
-        for i in event.ids() {
-            let mut iter = data.map.contexts_iter_mut(i);
-            while let Some(context) = iter.next() {
-                context.on_message(event.clone(), data.responder);
-            }
+        let mut iter = data.map.contexts_iter_mut(event.ids().into_iter());
+        while let Some(context) = iter.next() {
+            context.on_message(event.clone(), data.responder);
         }
     }
 }

--- a/correlation-parser/tests/empty_pattern.json
+++ b/correlation-parser/tests/empty_pattern.json
@@ -1,0 +1,19 @@
+[
+    {
+        "name": "GENERATED_LOGS",
+        "uuid": "f7ee6a32-03a6-40d9-bd87-f48d1b4cd563",
+        "conditions": {
+            "timeout": 4000
+        },
+        "actions": [
+            {
+              "message": {
+                  "uuid": "4bbd15c4-ec44-47a2-ada3-f7fe3ff81222",
+                  "inject_mode": "forward",
+                  "name": "GEN_LOGS",
+                  "message": "artificial test message"
+              }
+            }
+        ]
+    }
+]


### PR DESCRIPTION
If the pattern list is empty or not present, the context should subscribe to all events.
This case was implemented incorrectly, we need to track contexts with empty patterns separately,
and "append" these contexts to `ContextMap::contexts_iter_mut()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ihrwein/syslog-ng-rust-modules/43)
<!-- Reviewable:end -->
