### PR TITLE
Simplify ContextMap

### DIFF
--- a/correlation-parser/correlation/src/context/context_map.rs
+++ b/correlation-parser/correlation/src/context/context_map.rs
@@ -44,27 +44,22 @@ impl<E, T> ContextMap<E, T> where E: Event, T: Template<Event=E> {
     }
 
     pub fn insert(&mut self, context: Context<E, T>) {
+        let patterns = context.patterns().iter().cloned().collect::<Vec<String>>();
         self.contexts.push(context);
-        self.update_indices();
+        self.update_indices(patterns);
     }
 
-    fn update_indices(&mut self) {
-        let index_of_last_context = self.contexts.len() - 1;
-        let patterns : Vec<String> = self.contexts.last().expect("Failed to remove the last Context from a non empty vector")
-                                         .patterns().iter().cloned().collect();
-
+    fn update_indices(&mut self, patterns: Vec<String>) {
         if patterns.is_empty() {
-            self.empty_pattern_indices.push(index_of_last_context);
+            self.empty_pattern_indices.push(self.contexts.len() - 1);
         } else {
-            self.add_index_to_looked_up_index_vectors(index_of_last_context, &patterns);
+            self.add_index_to_looked_up_index_vectors(patterns);
         }
     }
 
-    fn add_index_to_looked_up_index_vectors(&mut self,
-                                            new_index: usize,
-                                            patterns: &[String]) {
+    fn add_index_to_looked_up_index_vectors(&mut self, patterns: Vec<String>) {
         for i in patterns {
-            self.map.entry(i.as_bytes().to_vec()).or_insert_with(Vec::new).push(new_index);
+            self.map.entry(i.as_bytes().to_vec()).or_insert_with(Vec::new).push(self.contexts.len() - 1);
         }
     }
 

--- a/correlation-parser/correlation/src/context/context_map.rs
+++ b/correlation-parser/correlation/src/context/context_map.rs
@@ -53,11 +53,11 @@ impl<E, T> ContextMap<E, T> where E: Event, T: Template<Event=E> {
         if patterns.is_empty() {
             self.empty_pattern_indices.push(self.contexts.len() - 1);
         } else {
-            self.add_index_to_looked_up_index_vectors(patterns);
+            self.update_indices_of_subscribed_contexts(patterns);
         }
     }
 
-    fn add_index_to_looked_up_index_vectors(&mut self, patterns: Vec<String>) {
+    fn update_indices_of_subscribed_contexts(&mut self, patterns: Vec<String>) {
         for i in patterns {
             self.map.entry(i.as_bytes().to_vec()).or_insert_with(Vec::new).push(self.contexts.len() - 1);
         }


### PR DESCRIPTION
This PR simplifies the `insert()` method of `ContextMap`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ihrwein/syslog-ng-rust-modules/46)
<!-- Reviewable:end -->
